### PR TITLE
Forward arguments to cursor constructor for Pooled connections

### DIFF
--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -103,10 +103,12 @@ class Pool:
                     break
 
     @asyncio.coroutine
-    def cursor(self):
+    def cursor(self, name=None, cursor_factory=None,
+                scrollable=None, withhold=False):
         """XXX"""
         conn = yield from self.acquire()
-        cur = yield from conn.cursor()
+        cur = yield from conn.cursor(name=name, cursor_factory=cursor_factory,
+                                     scrollable=scrollable, withhold=withhold)
         return _CursorContextManager(self, conn, cur)
 
     def __enter__(self):


### PR DESCRIPTION
Sometimes we need specify the cursor "type" without creation new connection for this and ignore cursor_factory attribute of the original connection.
