### PR TITLE
Fix IndexError exception in cursor.execute() when empty tuple passed by default

### DIFF
--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -79,7 +79,7 @@ class Cursor:
         self._impl.withhold = val
 
     @asyncio.coroutine
-    def execute(self, operation, parameters=()):
+    def execute(self, operation, parameters=None):
         """Prepare and execute a database operation (query or command).
 
         Parameters may be provided as sequence or mapping and will be


### PR DESCRIPTION
IndexError occured in psycopg2 when we pass query with "alones"  %-chars and empty tuple as params to unpack for this query.

By default in psycopg2 params is None, not empty tuple.
Second solution can be replace % -> %% for empty params list.

If you can't reproduce this with default cursor_factory try use any extra from psycopg2.extras
