### PR TITLE
issue with cursor __iter__

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,9 @@
 CHANGES
 -------
+0.6.1
+^^^^^
+
+* Drop iteration protocol support in cursor.
 
 0.6.0 (2015-02-03)
 ^^^^^^^^^^^^^^^^^^

--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -360,10 +360,3 @@ class Cursor:
     def timeout(self):
         """Return default timeout for cursor operations."""
         return self._timeout
-
-    def __iter__(self):
-        item = yield from self.fetchone()
-        if item is None:
-            raise StopIteration
-        else:
-            return item

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ def get_release():
             if match is not None:
                 return match.group(1)
         else:
-            raise RuntimeError('Cannot find version in aiozmq/__init__.py')
+            raise RuntimeError('Cannot find version in aiopg/__init__.py')
 
 
 def get_version(release):

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -445,19 +445,14 @@ Cursor
 
    .. _cursor-iterable:
 
-   .. note::
+   .. warning::
 
-      :class:`Cursor` objects are iterable, so, instead of calling
-      explicitly :meth:`Cursor.fetchone` in a loop, the object itself can
-      be used::
+      :class:`Cursor` objects do **not** support iteration, since
+      version 0.6.1.
 
-         >>> cur.execute("SELECT * FROM test;")
-         >>> for record in cur:
-         ...     print(record)
-         ...
-         (1, 100, "abc'def")
-         (2, None, 'dada')
-         (3, 42, 'bar')
+      Iterable protocol in :class:`Cursor` hides ``yield from`` from user,
+      witch should be explicit. Moreover iteration support is optional,
+      according to PEP-249 (https://www.python.org/dev/peps/pep-0249/#iter).
 
    .. method:: fetchone()
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -455,19 +455,6 @@ class TestCursor(unittest.TestCase):
 
         self.loop.run_until_complete(go())
 
-    def test_iter(self):
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect()
-            cur = yield from conn.cursor()
-            yield from cur.execute("SELECT * FROM tbl")
-            data = [(1, 'a'), (2, 'b'), (3, 'c')]
-            fetched_data = []
-            for item in cur:
-                fetched_data.append(item)
-            self.assertEquals(fetched_data, data)
-        self.loop.run_until_complete(go())
-
     def test_echo(self):
         @asyncio.coroutine
         def go():

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -5,7 +5,6 @@ import psycopg2.tz
 import time
 import unittest
 
-
 from aiopg.connection import TIMEOUT
 
 
@@ -463,9 +462,10 @@ class TestCursor(unittest.TestCase):
             cur = yield from conn.cursor()
             yield from cur.execute("SELECT * FROM tbl")
             data = [(1, 'a'), (2, 'b'), (3, 'c')]
-            for item, tst in zip(cur, data):
-                self.assertEqual(item, tst)
-
+            fetched_data = []
+            for item in cur:
+                fetched_data.append(item)
+            self.assertEquals(fetched_data, data)
         self.loop.run_until_complete(go())
 
     def test_echo(self):


### PR DESCRIPTION
I've modified little bit ``test_iter(self)`` test:

```python
    def test_iter(self):
        @asyncio.coroutine
        def go():
            conn = yield from self.connect()
            cur = yield from conn.cursor()
            yield from cur.execute("SELECT * FROM tbl")
            data = [(1, 'a'), (2, 'b'), (3, 'c')]
            fetched_data = []
            for item in cur:
                fetched_data.append(item)
            self.assertEquals(fetched_data, data)
        self.loop.run_until_complete(go())
```
And following issue poped up.

```python

======================================================================
FAIL: test_iter (tests.test_cursor.TestCursor)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/test_cursor.py", line 449, in test_iter
    self.loop.run_until_complete(go())
  File "/usr/lib/python3.4/asyncio/base_events.py", line 276, in run_until_complete
    return future.result()
  File "/usr/lib/python3.4/asyncio/futures.py", line 277, in result
    raise self._exception
  File "/usr/lib/python3.4/asyncio/tasks.py", line 237, in _step
    result = next(coro)
  File "tests/test_cursor.py", line 448, in go
    self.assertEquals(fetched_data, data)
AssertionError: Lists differ: [] != [(1, 'a'), (2, 'b'), (3, 'c')]

Second list contains 3 additional elements.
First extra element 0:
(1, 'a')

- []
+ [(1, 'a'), (2, 'b'), (3, 'c')]
```

looks like ``yield from``  or ``raise StopIteration``in  ``Cursor.__iter__`` method kills iteration.