### PR TITLE
Add psycopg2cffi support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ build
 .coverage
 htmlcov
 docs/_build
+pyvenv*/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+*.iml
 *.pyc
 __pycache__
 dist

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -1,9 +1,15 @@
 import asyncio
 
-import psycopg2
-from psycopg2.extensions import (
-    POLL_OK, POLL_READ, POLL_WRITE, POLL_ERROR)
-from psycopg2 import extras
+try:
+    import psycopg2cffi as psycopg2
+    from psycopg2cffi.extensions import (
+        POLL_OK, POLL_READ, POLL_WRITE, POLL_ERROR)
+    from psycopg2cffi import extras
+except ImportError:
+    import psycopg2
+    from psycopg2.extensions import (
+        POLL_OK, POLL_READ, POLL_WRITE, POLL_ERROR)
+    from psycopg2 import extras
 
 from .cursor import Cursor
 

--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -1,6 +1,9 @@
 import asyncio
 
-import psycopg2
+try:
+    import psycopg2cffi as psycopg2
+except ImportError:
+    import psycopg2
 
 from .log import logger
 

--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -1,8 +1,10 @@
 import asyncio
 import collections
 
-
-from psycopg2.extensions import TRANSACTION_STATUS_IDLE
+try:
+    from psycopg2cffi.extensions import TRANSACTION_STATUS_IDLE
+except ImportError:
+    from psycopg2.extensions import TRANSACTION_STATUS_IDLE
 
 from .connection import connect, TIMEOUT
 from .log import logger

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,10 +4,11 @@
    contain the root `toctree` directive.
 
 aiopg
-=================================
+=====
 
 .. _GitHub: https://github.com/aio-libs/aiopg
 .. _asyncio: http://docs.python.org/3.4/library/asyncio.html
+.. _psycopg2cffi: https://pypi.python.org/pypi/psycopg2cffi
 
 
 **aiopg** is a library for accessing a :term:`PostgreSQL` database
@@ -22,6 +23,7 @@ Features
   :ref:`aiopg-core-cursor` and :ref:`aiopg-core-pool` objects.
 - Implements *optional* support for charming :term:`sqlalchemy`
   functional sql layer.
+- You can use psycopg2cffi_ instead of psycopg2.
 
 
 Basics
@@ -109,7 +111,7 @@ convinient.
 
 
 Installation
---------------------
+------------
 
 .. code::
 
@@ -154,6 +156,7 @@ Dependencies
 - Python 3.3 and :mod:`asyncio` or Python 3.4+
 - psycopg2
 - aiopg.sa requires :term:`sqlalchemy`.
+- (Optional) psycopg2cffi_
 
 Authors and License
 -------------------

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ else:
 def read(f):
     return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
 
-extras_require = {'sa': ['sqlalchemy>=0.9'], }
+extras_require = {'sa': ['sqlalchemy>=0.9'], 'cffi': ['psycopg2cffi']}
 
 
 def read_version():

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,7 +1,11 @@
 import asyncio
 import aiopg
-import psycopg2
-import psycopg2.extras
+try:
+    import psycopg2cffi as psycopg2
+    import psycopg2cffi.extras as psycopg2_extras
+except ImportError:
+    import psycopg2
+    import psycopg2.extras as psycopg2_extras
 import socket
 import random
 import unittest
@@ -109,7 +113,7 @@ class TestConnection(unittest.TestCase):
         def go():
             conn = yield from self.connect()
             cur = yield from conn.cursor(
-                cursor_factory=psycopg2.extras.DictCursor)
+                cursor_factory=psycopg2_extras.DictCursor)
             yield from cur.execute('SELECT 1 AS a')
             ret = yield from cur.fetchone()
             self.assertEqual(1, ret['a'])
@@ -219,9 +223,9 @@ class TestConnection(unittest.TestCase):
         @asyncio.coroutine
         def go():
             conn = yield from self.connect(
-                cursor_factory=psycopg2.extras.DictCursor)
+                cursor_factory=psycopg2_extras.DictCursor)
 
-            self.assertIs(psycopg2.extras.DictCursor, conn.cursor_factory)
+            self.assertIs(psycopg2_extras.DictCursor, conn.cursor_factory)
 
         self.loop.run_until_complete(go())
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -1,7 +1,11 @@
 import asyncio
 import aiopg
-import psycopg2
-import psycopg2.tz
+try:
+    import psycopg2cffi as psycopg2
+    import psycopg2cffi.tz as psycopg2_tz
+except ImportError:
+    import psycopg2
+    import psycopg2.tz as psycopg2_tz
 import time
 import unittest
 
@@ -327,10 +331,10 @@ class TestCursor(unittest.TestCase):
         def go():
             conn = yield from self.connect()
             cur = yield from conn.cursor()
-            self.assertIs(psycopg2.tz.FixedOffsetTimezone, cur.tzinfo_factory)
+            self.assertIs(psycopg2_tz.FixedOffsetTimezone, cur.tzinfo_factory)
 
-            cur.tzinfo_factory = psycopg2.tz.LocalTimezone
-            self.assertIs(psycopg2.tz.LocalTimezone, cur.tzinfo_factory)
+            cur.tzinfo_factory = psycopg2_tz.LocalTimezone
+            self.assertIs(psycopg2_tz.LocalTimezone, cur.tzinfo_factory)
 
         self.loop.run_until_complete(go())
 

--- a/tests/test_extended_types.py
+++ b/tests/test_extended_types.py
@@ -3,7 +3,10 @@ import asyncio
 import unittest
 
 from aiopg import connect
-from psycopg2.extras import Json
+try:
+    from psycopg2cffi.extras import Json
+except ImportError:
+    from psycopg2.extras import Json
 
 
 class TestComplexPGTypesConnection(unittest.TestCase):

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -2,7 +2,10 @@ import asyncio
 import unittest
 from unittest import mock
 
-from psycopg2.extensions import TRANSACTION_STATUS_INTRANS
+try:
+    from psycopg2cffi.extensions import TRANSACTION_STATUS_INTRANS
+except ImportError:
+    from psycopg2.extensions import TRANSACTION_STATUS_INTRANS
 
 import aiopg
 from aiopg.connection import Connection, TIMEOUT

--- a/tests/test_sa_connection.py
+++ b/tests/test_sa_connection.py
@@ -6,7 +6,10 @@ import unittest
 from sqlalchemy import MetaData, Table, Column, Integer, String
 from sqlalchemy.schema import DropTable, CreateTable
 
-import psycopg2
+try:
+    import psycopg2cffi as psycopg2
+except ImportError:
+    import psycopg2
 
 
 meta = MetaData()

--- a/tests/test_sa_types.py
+++ b/tests/test_sa_types.py
@@ -1,7 +1,10 @@
 import asyncio
 import unittest
 
-import psycopg2
+try:
+    import psycopg2cffi as psycopg2
+except ImportError:
+    import psycopg2
 from aiopg import sa
 
 from sqlalchemy import MetaData, Table, Column, Integer


### PR DESCRIPTION
Hi,

This pull request adds `psycopg2cffi` support for `aiopg`.
Strategy used: if `psycopg2cffi` is present, use that instead of `psycopg2`.
If you have a better strategy to handle this use case without to be overcomplicated, feel free to propose something else.

Almost suite tests works, but you have small differences between both, like for dsn representation:

```
FAIL: test_dsn (tests.test_connection.TestConnection)
----------------------------------------------------------------------
Traceback (most recent call last):
File "tests/test_connection.py", line 197, in test_dsn
    self.loop.run_until_complete(go())
File "/home/lg/.pythonz/pythons/CPython-3.4.3/lib/python3.4/asyncio/base_events.py", line 316, in run_until_complete
    return future.result()
File "/home/lg/.pythonz/pythons/CPython-3.4.3/lib/python3.4/asyncio/futures.py", line 275, in result
    raise self._exception
File "/home/lg/.pythonz/pythons/CPython-3.4.3/lib/python3.4/asyncio/tasks.py", line 238, in _step
    result = next(coro)
File "tests/test_connection.py", line 195, in go
    conn.dsn)
AssertionError: 'dbname=aiopg user=aiopg password=xxxxxx host=127.0.0.1' != 'dbname=aiopg user=aiopg password=passwd host=127.0.0.1'
- dbname=aiopg user=aiopg password=xxxxxx host=127.0.0.1
?                                  ^^^^^^
+ dbname=aiopg user=aiopg password=passwd host=127.0.0.1
?                                  ^^^^^^
```

I imagine it isn't intentional, the goal of `psycopg2cffi` is to replace `psycopg2`.

From performance perspective, I've launched quickly some benchmarks with CPython 3.4.3: At least with the tests I've used from FrameworkBenchmarks, with `psycopg2`, it's always `psycopg2` that wins (+/- 30 %).

Nevertheless, integrate `psycopg2cffi` as alternative has two benefits:

With `psycopg2`, when one of my daemon is under high load, I've this error several times in my syslog:

```
asyncio:ERROR 2015-04-03 22:37:31,189 base_events.py:912 => Fatal error on aiopg connection: bad state in _ready callback connection: <aiopg.connection.Connection object at 0x7f0b6e938dd8>
```

With `psycopg2cffi`, no errors.

Moreover, with `psycopg2cffi` support, it's possible to use PyPy3 for `aiopg`. It isn't really functional for now, but I don't want to maintain an `aiopg` fork only for `psycopg2cffi` support during to try improve PyPy3 support.
