### PR TITLE
support for sqlalchemy 1.0.0

### DIFF
--- a/aiopg/sa/connection.py
+++ b/aiopg/sa/connection.py
@@ -92,7 +92,7 @@ class SAConnection:
                     processed_parameters.append(params)
                 post_processed_params = self._dialect.execute_sequence_format(
                     processed_parameters)
-                result_map = compiled.result_map
+                result_map = compiled._create_result_map()
             else:
                 if dp:
                     raise exc.ArgumentError("Don't mix sqlalchemy DDL clause "


### PR DESCRIPTION
SQLAchemy's 1.0.0 release is not working with current aiopg due to change of internal api. I do not know proper way to fix but changing `result_map` to `_create_result_map()` works fine.