### PR TITLE
get rid of ResultProxy._result_map

### DIFF
--- a/aiopg/sa/connection.py
+++ b/aiopg/sa/connection.py
@@ -66,7 +66,6 @@ class SAConnection:
             dp = dp[0]
 
         if isinstance(query, str):
-            result_map = None
             yield from cursor.execute(query, dp)
         elif isinstance(query, ClauseElement):
             compiled = query.compile(dialect=self._dialect)
@@ -92,20 +91,18 @@ class SAConnection:
                     processed_parameters.append(params)
                 post_processed_params = self._dialect.execute_sequence_format(
                     processed_parameters)
-                result_map = compiled.result_map
             else:
                 if dp:
                     raise exc.ArgumentError("Don't mix sqlalchemy DDL clause "
                                             "and execution with parameters")
                 post_processed_params = [compiled.construct_params()]
-                result_map = None
             yield from cursor.execute(str(compiled), post_processed_params[0])
         else:
             raise exc.ArgumentError("sql statement should be str or "
                                     "SQLAlchemy data "
                                     "selection/modification clause")
 
-        ret = ResultProxy(self, cursor, self._dialect, result_map)
+        ret = ResultProxy(self, cursor, self._dialect)
         self._weak_results.add(ret)
         return ret
 

--- a/aiopg/sa/result.py
+++ b/aiopg/sa/result.py
@@ -111,15 +111,8 @@ class ResultMetaData(object):
             # if dialect.requires_name_normalize:
             #     colname = dialect.normalize_name(colname)
 
-            if result_proxy._result_map:
-                try:
-                    name, obj, type_ = result_proxy._result_map[colname]
-                except KeyError:
-                    name, obj, type_ = \
-                        colname, None, typemap.get(coltype, sqltypes.NULLTYPE)
-            else:
-                name, obj, type_ = \
-                    colname, None, typemap.get(coltype, sqltypes.NULLTYPE)
+            name, obj, type_ = \
+                colname, None, typemap.get(coltype, sqltypes.NULLTYPE)
 
             processor = type_._cached_result_processor(dialect, coltype)
 
@@ -217,12 +210,11 @@ class ResultProxy:
     the originating SQL statement that produced this result set.
     """
 
-    def __init__(self, connection, cursor, dialect, result_map):
+    def __init__(self, connection, cursor, dialect, result_map=None):
         self._dialect = dialect
         self._closed = False
         self._cursor = cursor
         self._connection = connection
-        self._result_map = result_map
         self._rowcount = cursor.rowcount
 
         if cursor.description is not None:


### PR DESCRIPTION
Because `SQLCompiler.result_map` API has been removed in SQLAlchemy 1.0
(sqlalchemy diff https://github.com/zzzeek/sqlalchemy/commit/9854114f578833aee49b65e440319a0ec26daab6#diff-6e10aff76d8add452655df8180dc404bL667)