### PR TITLE
asynchronous context manager for cursors (experimental)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,7 @@
 [run]
 branch = True
 source = aiopg, tests
-omit = site-packages
+omit = site-packages, tests/test_pep492.py
 
 [html]
 directory = htmlcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "3.3"
   - "3.4"
+  - "3.5"
 
 before_install:
   - sudo apt-get update

--- a/Makefile
+++ b/Makefile
@@ -4,19 +4,17 @@ doc:
 	cd docs && make html
 	echo "open file://`pwd`/docs/_build/html/index.html"
 
-pep:
-	pep8 aiopg examples tests
-
 flake:
-	pyflakes aiopg examples tests
+	exclude=$$(python -c "import sys;sys.stdout.write('--exclude test_pep492.py') if sys.version_info[:3] < (3, 5, 0) else None"); \
+	flake8 aiopg examples tests $$exclude
 
-test: pep flake
+test: flake
 	py.test -q tests
 
-vtest: pep flake
+vtest: flake
 	py.test tests
 
-cov cover coverage: pep flake
+cov cover coverage: flake
 	py.test --cov=aiopg --cov=tests --cov-report=html --cov-report=term tests
 
 clean:
@@ -33,4 +31,4 @@ clean:
 	rm -rf docs/_build
 	rm -rf .tox
 
-.PHONY: all pep test vtest cov clean
+.PHONY: all test vtest cov clean

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -40,7 +40,8 @@ def _enable_hstore(conn):
 
 @asyncio.coroutine
 def connect(dsn=None, *, timeout=TIMEOUT, loop=None,
-            enable_json=True, enable_hstore=True, echo=False, **kwargs):
+            enable_json=True, enable_hstore=True, echo=False,
+            aio_connection_factory=None, **kwargs):
     """A factory for connecting to PostgreSQL.
 
     The coroutine accepts all parameters that psycopg2.connect() does
@@ -52,8 +53,13 @@ def connect(dsn=None, *, timeout=TIMEOUT, loop=None,
     if loop is None:
         loop = asyncio.get_event_loop()
 
+    if aio_connection_factory is None:
+        aio_connection_factory = Connection
+
     waiter = asyncio.Future(loop=loop)
-    conn = Connection(dsn, loop, timeout, waiter, bool(echo), **kwargs)
+    conn = aio_connection_factory(
+        dsn, loop, timeout, waiter, bool(echo), **kwargs
+    )
     try:
         yield from conn._poll(waiter, timeout)
     except Exception:

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -434,6 +434,7 @@ class _CursorContextManager:
         self._impl = impl
         self._timeout = timeout
         self._echo = echo
+        self._cursor = None
 
     def __iter__(self):
         impl = yield from self._impl

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -201,8 +201,6 @@ class Connection:
                             withhold=withhold)
         return _CursorContextManager(self, impl, timeout, self._echo)
 
-    cursor._is_coroutine = True
-
     @asyncio.coroutine
     def _cursor(self, name=None, cursor_factory=None,
                 scrollable=None, withhold=False):

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -40,8 +40,7 @@ def _enable_hstore(conn):
 
 @asyncio.coroutine
 def connect(dsn=None, *, timeout=TIMEOUT, loop=None,
-            enable_json=True, enable_hstore=True, echo=False,
-            aio_connection_factory=None, **kwargs):
+            enable_json=True, enable_hstore=True, echo=False, **kwargs):
     """A factory for connecting to PostgreSQL.
 
     The coroutine accepts all parameters that psycopg2.connect() does
@@ -53,13 +52,8 @@ def connect(dsn=None, *, timeout=TIMEOUT, loop=None,
     if loop is None:
         loop = asyncio.get_event_loop()
 
-    if aio_connection_factory is None:
-        aio_connection_factory = Connection
-
     waiter = asyncio.Future(loop=loop)
-    conn = aio_connection_factory(
-        dsn, loop, timeout, waiter, bool(echo), **kwargs
-    )
+    conn = Connection(dsn, loop, timeout, waiter, bool(echo), **kwargs)
     try:
         yield from conn._poll(waiter, timeout)
     except Exception:

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -434,6 +434,8 @@ class _CursorContextManager:
         impl = yield from self._impl
         return Cursor(self._conn, impl, self._timeout, self._echo)
 
+    __await__ = __iter__
+
     @asyncio.coroutine
     def __aenter__(self):
         self._cursor = yield from self

--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -376,3 +376,9 @@ class Cursor:
                 raise StopIteration
             else:
                 yield row
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ ipdb
 ipython
 pep8
 pyflakes
+mccabe
+flake8
 wheel
 setuptools
 -e .[sa]

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -108,6 +108,19 @@ class TestConnection(unittest.TestCase):
 
         self.loop.run_until_complete(go())
 
+    def test_with_connection_factory(self):
+        class Subclassed(aiopg.connection.Connection):
+            pass
+
+        @asyncio.coroutine
+        def go():
+            conn = yield from self.connect(
+                aio_connection_factory=Subclassed,
+            )
+            self.assertIsInstance(conn, Subclassed)
+
+        self.loop.run_until_complete(go())
+
     def test_with_cursor_factory(self):
 
         @asyncio.coroutine

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -109,19 +109,6 @@ class TestConnection(unittest.TestCase):
 
         self.loop.run_until_complete(go())
 
-    def test_with_connection_factory(self):
-        class Subclassed(aiopg.connection.Connection):
-            pass
-
-        @asyncio.coroutine
-        def go():
-            conn = yield from self.connect(
-                aio_connection_factory=Subclassed,
-            )
-            self.assertIsInstance(conn, Subclassed)
-
-        self.loop.run_until_complete(go())
-
     def test_with_cursor_factory(self):
 
         @asyncio.coroutine

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,3 +1,4 @@
+import pytest
 import asyncio
 import aiopg
 import gc
@@ -240,6 +241,48 @@ class TestConnection(unittest.TestCase):
                 cursor_factory=psycopg2.extras.DictCursor)
 
             self.assertIs(psycopg2.extras.DictCursor, conn.cursor_factory)
+
+        self.loop.run_until_complete(go())
+
+    def test_cursor_async_context_manager(self):
+
+        def go():
+            conn = yield from self.connect()
+
+            # The following code is equivalent to:
+            #
+            # async with conn.cursor() as cur:
+            #     await cur.execute('SELECT 1')
+            #
+            # However, this throws a syntax error in Python <3.5, so we have to
+            # use this shim.  Taken from
+            # https://www.python.org/dev/peps/pep-0492/#new-syntax
+
+            mgr = conn.cursor()
+            aexit = type(mgr).__aexit__
+            aenter = type(mgr).__aenter__(mgr)
+            exc = True
+
+            cur = yield from aenter
+            try:
+                yield from cur.execute('SELECT 1')
+            except:
+                if not (yield from aexit(mgr, *sys.exc_info())):
+                    raise
+            else:
+                yield from aexit(mgr, None, None, None)
+            self.assertTrue(cur.closed)
+
+        self.loop.run_until_complete(go())
+
+    @pytest.mark.xfail
+    def test_cursor_inspect(self):
+        import inspect
+
+        def go():
+            conn = yield from self.connect()
+            self.assertTrue(asyncio.iscoroutinefunction(conn.cursor))
+            self.assertTrue(asyncio.iscoroutine(conn.cursor()))
 
         self.loop.run_until_complete(go())
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,4 +1,3 @@
-import pytest
 import asyncio
 import aiopg
 import gc
@@ -231,15 +230,17 @@ class TestConnection(unittest.TestCase):
 
         self.loop.run_until_complete(go())
 
-    @pytest.mark.xfail
     def test_cursor_inspect(self):
 
         def go():
             conn = yield from self.connect()
-            self.assertTrue(asyncio.iscoroutinefunction(conn.cursor))
             self.assertTrue(asyncio.iscoroutine(conn.cursor()))
 
         self.loop.run_until_complete(go())
+
+    def test_cursor_run_until_complete(self):
+        conn = self.loop.run_until_complete(self.connect())
+        self.loop.run_until_complete(conn.cursor())
 
     def test_notices(self):
 

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -76,6 +76,18 @@ class TestCursor(unittest.TestCase):
 
         self.loop.run_until_complete(go())
 
+    def test_context_manager(self):
+        @asyncio.coroutine
+        def go():
+            conn = yield from self.connect()
+            with (yield from conn.cursor()) as cur:
+                yield from cur.execute('SELECT 1')
+                ret = yield from cur.fetchone()
+                self.assertEqual((1,), ret)
+            self.assertTrue(cur.closed)
+
+        self.loop.run_until_complete(go())
+
     def test_raw(self):
 
         @asyncio.coroutine

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -1,0 +1,42 @@
+"""
+A test suite for Python 3.5's new async and await syntax.
+
+"""
+
+import unittest
+import asyncio
+
+import aiopg
+
+
+class TestConnection(unittest.TestCase):
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
+    def tearDown(self):
+        self.loop.close()
+        self.loop = None
+
+    async def connect(self, no_loop=False, **kwargs):
+        loop = None if no_loop else self.loop
+        conn = await aiopg.connect(database='aiopg',
+                                   user='aiopg',
+                                   password='passwd',
+                                   host='127.0.0.1',
+                                   loop=loop,
+                                   **kwargs)
+        self.addCleanup(conn.close)
+        return conn
+
+    def test_cursor_async_context_manager(self):
+
+        async def go():
+            conn = await self.connect()
+
+            async with conn.cursor() as cur:
+                await cur.execute('SELECT 1')
+            self.assertTrue(cur.closed)
+
+        self.loop.run_until_complete(go())

--- a/tests/test_pep492.py
+++ b/tests/test_pep492.py
@@ -40,3 +40,14 @@ class TestConnection(unittest.TestCase):
             self.assertTrue(cur.closed)
 
         self.loop.run_until_complete(go())
+
+    def test_cursor_await(self):
+
+        async def go():
+            conn = await self.connect()
+
+            cur = await conn.cursor()
+            await cur.execute('SELECT 1')
+            cur.close()
+
+        self.loop.run_until_complete(go())


### PR DESCRIPTION
This is to support the following paradigms:

```python
with (yield from conn.cursor()) as cur:
    cur.execute('SELECT 1')
```

And, in Python 3.5:

```python
async with conn.cursor() as cur:
    cur.execute('SELECT 1')
```

Right now, conn.cursor() returns an awaitable, coroutine-like object, but it is not actually a coroutine.  Not sure if this is a problem.  Python doesn't enforce it.

Potential additional features:

* Implement same functionality for `Pool.cursor()`
* Context manager for transactions, e.g. `async with conn:  # This begins and commits/rollbacks transaction`

I have to step off of this for the moment, so thought I show what I've done so far.