### PR TITLE
Create/drop tables using metadata in aiopg.sa

### DIFF
--- a/aiopg/sa/__init__.py
+++ b/aiopg/sa/__init__.py
@@ -3,6 +3,7 @@ from .connection import SAConnection
 from .engine import create_engine, Engine
 from .exc import (Error, ArgumentError, InvalidRequestError,
                   NoSuchColumnError, ResourceClosedError)
+from .ddl import AsyncMetaData
 
 
 __all__ = ('create_engine', 'SAConnection', 'Error',
@@ -11,4 +12,5 @@ __all__ = ('create_engine', 'SAConnection', 'Error',
 
 
 (SAConnection, Error, ArgumentError, InvalidRequestError,
- NoSuchColumnError, ResourceClosedError, create_engine, Engine)
+ NoSuchColumnError, ResourceClosedError, create_engine, Engine,
+ AsyncMetaData)

--- a/aiopg/sa/connection.py
+++ b/aiopg/sa/connection.py
@@ -318,6 +318,11 @@ class SAConnection:
         self._connection = None
         self._engine = None
 
+    @asyncio.coroutine
+    def _run_visitor(self, visitorcallable, element, **kwargs):
+        yield from visitorcallable(self._dialect, self,
+                                   **kwargs).traverse_single(element)
+
 
 def _distill_params(multiparams, params):
     """Given arguments from the calling form *multiparams, **params,

--- a/aiopg/sa/ddl.py
+++ b/aiopg/sa/ddl.py
@@ -1,0 +1,326 @@
+import asyncio
+from aiopg.sa.visitor import AsyncClauseVisitor
+from sqlalchemy import util, MetaData
+from sqlalchemy.exc import CircularDependencyError
+from sqlalchemy.sql.base import _bind_or_error
+from sqlalchemy.sql.ddl import sort_tables_and_constraints, CreateTable,\
+    AddConstraint, CreateSequence, \
+    CreateIndex, DropSequence, DropConstraint, DropTable, DropIndex
+
+
+class AsyncMetaData(MetaData):
+    @asyncio.coroutine
+    def create_all(self, bind=None, tables=None, checkfirst=True):
+        if bind is None:
+            bind = _bind_or_error(self)
+        yield from bind._run_visitor(SchemaGenerator,
+                                     self,
+                                     checkfirst=checkfirst,
+                                     tables=tables)
+
+    @asyncio.coroutine
+    def drop_all(self, bind=None, tables=None, checkfirst=True):
+        if bind is None:
+            bind = _bind_or_error(self)
+        yield from bind._run_visitor(SchemaDropper,
+                                     self,
+                                     checkfirst=checkfirst,
+                                     tables=tables)
+
+
+class SchemaGenerator(AsyncClauseVisitor):
+    __traverse_options__ = {'schema_visitor': True}
+
+    def __init__(self, dialect, connection, checkfirst=False,
+                 tables=None, **kwargs):
+        self.connection = connection
+        self.checkfirst = checkfirst
+        self.tables = tables
+        self.preparer = dialect.identifier_preparer
+        self.dialect = dialect
+        self.memo = {}
+
+    @asyncio.coroutine
+    def _can_create_table(self, table):
+        self.dialect.validate_identifier(table.name)
+        if table.schema:
+            self.dialect.validate_identifier(table.schema)
+        has_table = yield from self.dialect.has_table(self.connection,
+                                                      table.name,
+                                                      schema=table.schema)
+        return not self.checkfirst or not has_table
+
+    @asyncio.coroutine
+    def _can_create_sequence(self, sequence):
+        has_sequence = yield from self.dialect.has_sequence(
+                            self.connection,
+                            sequence.name,
+                            schema=sequence.schema)
+        return self.dialect.supports_sequences and \
+            (
+                (not self.dialect.sequences_optional or
+                 not sequence.optional) and
+                (
+                    not self.checkfirst or
+                    not has_sequence
+                )
+            )
+
+    @asyncio.coroutine
+    def visit_metadata(self, metadata):
+        if self.tables is not None:
+            tables = self.tables
+        else:
+            tables = list(metadata.tables.values())
+
+        ts = []
+        for t in tables:
+            r = yield from self._can_create_table(t)
+            if r:
+                ts.append(t)
+        collection = sort_tables_and_constraints(ts)
+
+        seq_coll = [s for s in metadata._sequences.values()
+                    if s.column is None and self._can_create_sequence(s)]
+
+        event_collection = [
+            t for (t, fks) in collection if t is not None
+        ]
+        metadata.dispatch.before_create(metadata, self.connection,
+                                        tables=event_collection,
+                                        checkfirst=self.checkfirst,
+                                        _ddl_runner=self)
+
+        for seq in seq_coll:
+            yield from self.traverse_single(seq, create_ok=True)
+
+        for table, fkcs in collection:
+            if table is not None:
+                yield from self.traverse_single(
+                    table, create_ok=True,
+                    include_foreign_key_constraints=fkcs,
+                    _is_metadata_operation=True)
+            else:
+                for fkc in fkcs:
+                    yield from self.traverse_single(fkc)
+
+        metadata.dispatch.after_create(metadata, self.connection,
+                                       tables=event_collection,
+                                       checkfirst=self.checkfirst,
+                                       _ddl_runner=self)
+
+    @asyncio.coroutine
+    def visit_table(
+            self, table, create_ok=False,
+            include_foreign_key_constraints=None,
+            _is_metadata_operation=False):
+        can_create_table = yield from self._can_create_table(table)
+        if not create_ok and not can_create_table:
+            return
+
+        table.dispatch.before_create(
+            table, self.connection,
+            checkfirst=self.checkfirst,
+            _ddl_runner=self,
+            _is_metadata_operation=_is_metadata_operation)
+
+        for column in table.columns:
+            if column.default is not None:
+                yield from self.traverse_single(column.default)
+
+        if not self.dialect.supports_alter:
+            # e.g., don't omit any foreign key constraints
+            include_foreign_key_constraints = None
+
+        yield from self.connection.execute(
+            CreateTable(
+                table,
+                include_foreign_key_constraints=include_foreign_key_constraints
+            ))
+
+        if hasattr(table, 'indexes'):
+            for index in table.indexes:
+                yield from self.traverse_single(index)
+
+        table.dispatch.after_create(
+            table, self.connection,
+            checkfirst=self.checkfirst,
+            _ddl_runner=self,
+            _is_metadata_operation=_is_metadata_operation)
+
+    @asyncio.coroutine
+    def visit_foreign_key_constraint(self, constraint):
+        if not self.dialect.supports_alter:
+            return
+        yield from self.connection.execute(AddConstraint(constraint))
+
+    @asyncio.coroutine
+    def visit_sequence(self, sequence, create_ok=False):
+        if not create_ok and not self._can_create_sequence(sequence):
+            return
+        yield from self.connection.execute(CreateSequence(sequence))
+
+    @asyncio.coroutine
+    def visit_index(self, index):
+        yield from self.connection.execute(CreateIndex(index))
+
+
+class SchemaDropper(AsyncClauseVisitor):
+    __traverse_options__ = {'schema_visitor': True}
+
+    def __init__(self, dialect, connection, checkfirst=False,
+                 tables=None, **kwargs):
+        self.connection = connection
+        self.checkfirst = checkfirst
+        self.tables = tables
+        self.preparer = dialect.identifier_preparer
+        self.dialect = dialect
+        self.memo = {}
+
+    @asyncio.coroutine
+    def visit_metadata(self, metadata):
+        if self.tables is not None:
+            tables = self.tables
+        else:
+            tables = list(metadata.tables.values())
+
+        try:
+            unsorted_tables = []
+            for t in tables:
+                can_drop_table = yield from self._can_drop_table(t)
+                if can_drop_table:
+                    unsorted_tables.append(t)
+            collection = list(reversed(
+                sort_tables_and_constraints(
+                    unsorted_tables,
+                    filter_fn=lambda constraint: False
+                    if not self.dialect.supports_alter or
+                    constraint.name is None
+                    else None
+                )
+            ))
+        except CircularDependencyError as err2:
+            if not self.dialect.supports_alter:
+                util.warn(
+                    "Can't sort tables for DROP; an "
+                    "unresolvable foreign key "
+                    "dependency exists between tables: %s, and backend does "
+                    "not support ALTER.  To restore at least a partial sort, "
+                    "apply use_alter=True to ForeignKey and "
+                    "ForeignKeyConstraint "
+                    "objects involved in the cycle to mark these as known "
+                    "cycles that will be ignored."
+                    % (
+                        ", ".join(sorted([t.fullname for t in err2.cycles]))
+                    )
+                )
+                collection = [(t, ()) for t in unsorted_tables]
+            else:
+                util.raise_from_cause(
+                    CircularDependencyError(
+                        err2.args[0],
+                        err2.cycles, err2.edges,
+                        msg="Can't sort tables for DROP; an "
+                        "unresolvable foreign key "
+                        "dependency exists between tables: %s.  Please ensure "
+                        "that the ForeignKey and ForeignKeyConstraint objects "
+                        "involved in the cycle have "
+                        "names so that they can be dropped using "
+                        "DROP CONSTRAINT."
+                        % (
+                            ", ".join(
+                                sorted([t.fullname for t in err2.cycles]))
+                        )
+
+                    )
+                )
+
+        seq_coll = []
+        for s in metadata._sequences.values():
+            if s.column is None and (yield from self._can_drop_sequence(s)):
+                seq_coll.append(s)
+
+        event_collection = [
+            t for (t, fks) in collection if t is not None
+        ]
+
+        metadata.dispatch.before_drop(
+            metadata, self.connection, tables=event_collection,
+            checkfirst=self.checkfirst, _ddl_runner=self)
+
+        for table, fkcs in collection:
+            if table is not None:
+                yield from self.traverse_single(
+                    table, drop_ok=True, _is_metadata_operation=True)
+            else:
+                for fkc in fkcs:
+                    yield from self.traverse_single(fkc)
+
+        for seq in seq_coll:
+            yield from self.traverse_single(seq, drop_ok=True)
+
+        metadata.dispatch.after_drop(
+            metadata, self.connection, tables=event_collection,
+            checkfirst=self.checkfirst, _ddl_runner=self)
+
+    @asyncio.coroutine
+    def _can_drop_table(self, table):
+        self.dialect.validate_identifier(table.name)
+        if table.schema:
+            self.dialect.validate_identifier(table.schema)
+        return not self.checkfirst or (
+            yield from self.dialect.has_table(
+                self.connection, table.name, schema=table.schema)
+        )
+
+    @asyncio.coroutine
+    def _can_drop_sequence(self, sequence):
+        return self.dialect.supports_sequences and \
+            ((not self.dialect.sequences_optional or
+              not sequence.optional) and
+                (not self.checkfirst or
+                 (yield from self.dialect.has_sequence(
+                         self.connection,
+                         sequence.name,
+                         schema=sequence.schema))
+                 )
+             )
+
+    @asyncio.coroutine
+    def visit_index(self, index):
+        yield from self.connection.execute(DropIndex(index))
+
+    @asyncio.coroutine
+    def visit_table(self, table, drop_ok=False, _is_metadata_operation=False):
+        if not drop_ok and not (yield from self._can_drop_table(table)):
+            return
+
+        table.dispatch.before_drop(
+            table, self.connection,
+            checkfirst=self.checkfirst,
+            _ddl_runner=self,
+            _is_metadata_operation=_is_metadata_operation)
+
+        for column in table.columns:
+            if column.default is not None:
+                yield from self.traverse_single(column.default)
+
+        yield from self.connection.execute(DropTable(table))
+
+        table.dispatch.after_drop(
+           table, self.connection,
+           checkfirst=self.checkfirst,
+           _ddl_runner=self,
+           _is_metadata_operation=_is_metadata_operation)
+
+    @asyncio.coroutine
+    def visit_foreign_key_constraint(self, constraint):
+        if not self.dialect.supports_alter:
+            return
+        yield from self.connection.execute(DropConstraint(constraint))
+
+    @asyncio.coroutine
+    def visit_sequence(self, sequence, drop_ok=False):
+        if not drop_ok and not self._can_drop_sequence(sequence):
+            return
+        yield from self.connection.execute(DropSequence(sequence))

--- a/aiopg/sa/dialect.py
+++ b/aiopg/sa/dialect.py
@@ -1,0 +1,131 @@
+import asyncio
+try:
+    from sqlalchemy.dialects.postgresql.psycopg2 import PGDialect_psycopg2
+    from sqlalchemy import sql
+    from sqlalchemy import util
+    from sqlalchemy.sql import sqltypes
+except ImportError:  # pragma: no cover
+    raise ImportError('aiopg.sa requires sqlalchemy')
+
+
+class PGDialect_psycopg2_aio(PGDialect_psycopg2):
+    """
+    PGDialect that redefines some methods in asynchronous style
+    """
+
+    @asyncio.coroutine
+    def has_schema(self, connection, schema):
+        query = ("select nspname from pg_namespace "
+                 "where lower(nspname)=:schema")
+        cursor = yield from connection.execute(
+            sql.text(
+                query,
+                bindparams=[
+                    sql.bindparam(
+                        'schema', util.text_type(schema.lower()),
+                        type_=sqltypes.Unicode)]
+            )
+        )
+
+        response = yield from cursor.first()
+        return bool(response)
+
+    @asyncio.coroutine
+    def has_table(self, connection, table_name, schema=None):
+        # seems like case gets folded in pg_class...
+        if schema is None:
+            cursor = yield from connection.execute(
+                sql.text(
+                    "select relname from pg_class c join pg_namespace n on "
+                    "n.oid=c.relnamespace where "
+                    "pg_catalog.pg_table_is_visible(c.oid) "
+                    "and relname=:name",
+                    bindparams=[
+                        sql.bindparam('name', util.text_type(table_name),
+                                      type_=sqltypes.Unicode)]
+                )
+            )
+        else:
+            cursor = yield from connection.execute(
+                sql.text(
+                    "select relname from pg_class c join pg_namespace n on "
+                    "n.oid=c.relnamespace where n.nspname=:schema and "
+                    "relname=:name",
+                    bindparams=[
+                        sql.bindparam('name',
+                                      util.text_type(table_name),
+                                      type_=sqltypes.Unicode),
+                        sql.bindparam('schema',
+                                      util.text_type(schema),
+                                      type_=sqltypes.Unicode)]
+                )
+            )
+        response = yield from cursor.first()
+        return bool(response)
+
+    @asyncio.coroutine
+    def has_sequence(self, connection, sequence_name, schema=None):
+        if schema is None:
+            cursor = yield from connection.execute(
+                sql.text(
+                    "SELECT relname FROM pg_class c join pg_namespace n on "
+                    "n.oid=c.relnamespace where relkind='S' and "
+                    "n.nspname=current_schema() "
+                    "and relname=:name",
+                    bindparams=[
+                        sql.bindparam('name', util.text_type(sequence_name),
+                                      type_=sqltypes.Unicode)
+                    ]
+                )
+            )
+        else:
+            cursor = yield from connection.execute(
+                sql.text(
+                    "SELECT relname FROM pg_class c join pg_namespace n on "
+                    "n.oid=c.relnamespace where relkind='S' and "
+                    "n.nspname=:schema and relname=:name",
+                    bindparams=[
+                        sql.bindparam('name', util.text_type(sequence_name),
+                                      type_=sqltypes.Unicode),
+                        sql.bindparam('schema',
+                                      util.text_type(schema),
+                                      type_=sqltypes.Unicode)
+                    ]
+                )
+            )
+        response = yield from cursor.first()
+        return bool(response)
+
+    @asyncio.coroutine
+    def has_type(self, connection, type_name, schema=None):
+        if schema is not None:
+            query = """
+            SELECT EXISTS (
+                SELECT * FROM pg_catalog.pg_type t, pg_catalog.pg_namespace n
+                WHERE t.typnamespace = n.oid
+                AND t.typname = :typname
+                AND n.nspname = :nspname
+                )
+                """
+            query = sql.text(query)
+        else:
+            query = """
+            SELECT EXISTS (
+                SELECT * FROM pg_catalog.pg_type t
+                WHERE t.typname = :typname
+                AND pg_type_is_visible(t.oid)
+                )
+                """
+            query = sql.text(query)
+        query = query.bindparams(
+            sql.bindparam('typname',
+                          util.text_type(type_name), type_=sqltypes.Unicode),
+        )
+        if schema is not None:
+            query = query.bindparams(
+                sql.bindparam('nspname',
+                              util.text_type(schema), type_=sqltypes.Unicode),
+            )
+        cursor = yield from connection.execute(query)
+        response = yield from cursor.scalar()
+        return bool(response)

--- a/aiopg/sa/visitor.py
+++ b/aiopg/sa/visitor.py
@@ -1,0 +1,39 @@
+import asyncio
+from sqlalchemy.sql import ClauseVisitor
+from sqlalchemy.sql.visitors import iterate
+
+
+@asyncio.coroutine
+def traverse_using(iterator, obj, visitors):
+    """visit the given expression structure using the given iterator of
+    objects.
+
+    """
+    for target in iterator:
+        meth = visitors.get(target.__visit_name__, None)
+        if meth:
+            yield from meth(target)
+    return obj
+
+
+@asyncio.coroutine
+def traverse(obj, opts, visitors):
+    """traverse and visit the given expression structure using the default
+     iterator.
+    """
+    yield from traverse_using(iterate(obj, opts), obj, visitors)
+
+
+class AsyncClauseVisitor(ClauseVisitor):
+    @asyncio.coroutine
+    def traverse_single(self, obj, **kw):
+        for v in self._visitor_iterator:
+            meth = getattr(v, "visit_%s" % obj.__visit_name__, None)
+            if meth:
+                yield from meth(obj, **kw)
+
+    @asyncio.coroutine
+    def traverse(self, obj):
+        """traverse and visit the given expression structure."""
+
+        yield from traverse(obj, self.__traverse_options__, self._visitor_dict)

--- a/aiopg/sa/visitor.py
+++ b/aiopg/sa/visitor.py
@@ -21,7 +21,8 @@ def traverse(obj, opts, visitors):
     """traverse and visit the given expression structure using the default
      iterator.
     """
-    yield from traverse_using(iterate(obj, opts), obj, visitors)
+    result = yield from traverse_using(iterate(obj, opts), obj, visitors)
+    return result
 
 
 class AsyncClauseVisitor(ClauseVisitor):
@@ -36,4 +37,5 @@ class AsyncClauseVisitor(ClauseVisitor):
     def traverse(self, obj):
         """traverse and visit the given expression structure."""
 
-        yield from traverse(obj, self.__traverse_options__, self._visitor_dict)
+        result = yield from traverse(obj, self.__traverse_options__, self._visitor_dict)
+        return result

--- a/tests/test_sa_metadata.py
+++ b/tests/test_sa_metadata.py
@@ -1,0 +1,59 @@
+import asyncio
+from aiopg import connect
+
+import unittest
+from unittest import mock
+
+import pytest
+sa = pytest.importorskip("aiopg.sa")  # noqa
+
+
+from sqlalchemy import Table, Column, Integer, String
+
+import psycopg2
+
+
+meta = sa.AsyncMetaData()
+tbl = Table('sa_tbl', meta,
+            Column('id', Integer, nullable=False,
+                   primary_key=True),
+            Column('name', String(255)))
+
+
+class TestSAConnection(unittest.TestCase):
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+        self.raw_connection = None
+
+    def tearDown(self):
+        self.raw_connection.close()
+        self.loop.close()
+
+    @asyncio.coroutine
+    def connect(self, **kwargs):
+        conn = yield from connect(database='aiopg',
+                                  user='aiopg',
+                                  password='passwd',
+                                  host='127.0.0.1',
+                                  loop=self.loop,
+                                  **kwargs)
+        self.raw_connection = conn
+        engine = mock.Mock(from_spec=sa.engine.Engine)
+        engine.dialect = sa.engine._dialect
+        return sa.SAConnection(conn, engine)
+
+    def test_metadata_create_drop(self, **kwargs):
+        @asyncio.coroutine
+        def go():
+            conn = yield from self.connect()
+
+            yield from meta.drop_all(conn)
+            with self.assertRaises(psycopg2.ProgrammingError):
+                yield from conn.execute("SELECT * FROM sa_tbl")
+
+            yield from meta.create_all(conn)
+            res = yield from conn.execute("SELECT * FROM sa_tbl")
+            self.assertEqual(0, len(list(res)))
+
+        self.loop.run_until_complete(go())


### PR DESCRIPTION
Instead of using workarounds like 
```
res = yield from conn.execute(CreateTable(tbl))
```
with this patch it's available to create/drop tables via native sqlalchemy way via metadata
```
meta = sa.AsyncMetaData()
tbl = Table('sa_tbl', meta,
            Column('id', Integer, nullable=False,
                   primary_key=True),
            Column('name', String(255)))
conn = yield from self.connect()
yield from meta.create_all(conn)
```

Not the best implementation, because contains lot of repeated code from SA, but at least for end user it's more transparent.