### PR TITLE
If execute times out, handle possible cancel timeout.

### DIFF
--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -111,7 +111,10 @@ class Cursor:
         try:
             yield from self._conn._poll(waiter, timeout)
         except asyncio.TimeoutError:
-            yield from self._conn.cancel()
+            try:
+                yield from self._conn.cancel()
+            except asyncio.TimeoutError:
+                pass
             self._impl.close()
             raise
 


### PR DESCRIPTION
execute was fixed to close the cursor if it timed out, to prevent a subsequent 'query in flight' error.  However, the test assumes that cancel will not time out.  This patch introduces a test for the case where the cancel *also* times out, and fixes it by ignoring the cancel timeout in the execute timeout error recovery.

I assume that extending the original fix in this way is correct, but I'm not really sure about what happens to the transaction that timed out from aiopg's point of view.  In my application code I'm currently dealing with the timeout by checking the DB before doing a retry...I'll find out some time in the next couple of days if that actually works :)