### PR TITLE
fix patched engine release in transaction tests

### DIFF
--- a/tests/test_sa_transaction.py
+++ b/tests/test_sa_transaction.py
@@ -60,10 +60,8 @@ class TestTransaction(unittest.TestCase):
         engine = mock.Mock()
         engine.dialect = sa.engine._dialect
 
-        @asyncio.coroutine
         def release(*args):
             return
-            yield
         engine.release = release
 
         ret = sa.SAConnection(conn, engine)


### PR DESCRIPTION
Engine.release is not coroutine, no need to patch it with coroutine.