### PR TITLE
asyncio.async() is deprecated in favor of asyncio.ensure_future()

### DIFF
--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -238,7 +238,10 @@ class Pool(asyncio.AbstractServer):
                 conn.close()
             else:
                 self._free.append(conn)
-            fut = asyncio.async(self._wakeup(), loop=self._loop)
+            try:
+                fut = asyncio.ensure_future(self._wakeup(), loop=self._loop)
+            except AttributeError:
+                fut = asyncio.async(self._wakeup(), loop=self._loop)
         return fut
 
     @asyncio.coroutine


### PR DESCRIPTION
Not sure if we really need to support an older version, but I think that backwards compatibility is generally a good idea.