### PR TITLE
Don't crash when Connection is GC'ed

### DIFF
--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -449,7 +449,11 @@ class Connection:
 
     if PY_341:  # pragma: no branch
         def __del__(self):
-            if not self._conn.closed:
+            try:
+                _conn = self._conn
+            except AttributeError:
+                return
+            if _conn is not None and not _conn.closed:
                 self.close()
                 warnings.warn("Unclosed connection {!r}".format(self),
                               ResourceWarning)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -543,3 +543,10 @@ def test_close_cursor_on_timeout_error(connect):
     assert not conn.closed
 
     yield from conn.close()
+
+
+@pytest.mark.run_loop
+def test_issue_111_crash_on_connect_error(loop):
+    import aiopg.connection
+    with pytest.raises(psycopg2.OperationalError):
+        yield from aiopg.connection.connect('baddsn:1', loop=loop)


### PR DESCRIPTION
`Connection` `_conn` attribute might not be set if `__init__` crashes early
due to a psycopg error on connect.

Make sure `__del__` does not crash when this happens.

Closes #111