### PR TITLE
Revert "README examples with syntax highlighting"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ asynchronous features of the Psycopg database driver.
 Example
 -------
 
-.. code:: python
+::
 
     import asyncio
     import aiopg
@@ -36,7 +36,7 @@ Example
 Example of SQLAlchemy optional integration
 ------------------------------------------
 
-.. code:: python
+::
 
    import asyncio
    from aiopg.sa import create_engine


### PR DESCRIPTION
Reverts aio-libs/aiopg#131

It breaks `python setup.py check -rms` command