### PR TITLE
Remove callbacks from a bad file descriptor immediately

### DIFF
--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import errno
 import fcntl
 import sys
@@ -126,11 +127,8 @@ class Connection:
                     fcntl.fcntl(self._fileno, fcntl.F_GETFD)
                 except OSError as os_exc:
                     if os_exc.errno == errno.EBADF:
-                        try:
+                        with contextlib.suppress(OSError):
                             self._loop.remove_reader(self._fileno)
-                        except OSError as os_exc2:
-                            if os_exc2.errno == errno.EBADF:
-                                pass
                 finally:
                     # forget a bad file descriptor, don't try to touch it
                     self._fileno = None

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -1,5 +1,6 @@
 import asyncio
 import errno
+import fcntl
 import sys
 import traceback
 import warnings
@@ -120,10 +121,25 @@ class Connection:
                 notify = self._conn.notifies.pop(0)
                 self._notifies.put_nowait(notify)
         except (psycopg2.Warning, psycopg2.Error) as exc:
+            if self._fileno is not None:
+                try:
+                    fcntl.fcntl(self._fileno, fcntl.F_GETFD)
+                except OSError as os_exc:
+                    if os_exc.errno == errno.EBADF:
+                        try:
+                            self._loop.remove_reader(self._fileno)
+                        except OSError as os_exc2:
+                            if os_exc2.errno == errno.EBADF:
+                                pass
+                finally:
+                    # forget a bad file descriptor, don't try to touch it
+                    self._fileno = None
+
             try:
                 if self._writing:
                     self._writing = False
-                    self._loop.remove_writer(self._fileno)
+                    if self._fileno is not None:
+                        self._loop.remove_writer(self._fileno)
             except OSError as exc2:
                 if exc2.errno != errno.EBADF:
                     # EBADF is ok for closed file descriptor
@@ -244,10 +260,11 @@ class Connection:
         """Remove the connection from the event_loop and close it."""
         # N.B. If connection contains uncommitted transaction the
         # transaction will be discarded
-        self._loop.remove_reader(self._fileno)
-        if self._writing:
-            self._writing = False
-            self._loop.remove_writer(self._fileno)
+        if self._fileno is not None:
+            self._loop.remove_reader(self._fileno)
+            if self._writing:
+                self._writing = False
+                self._loop.remove_writer(self._fileno)
         self._conn.close()
         if self._waiter is not None and not self._waiter.done():
             self._waiter.set_exception(


### PR DESCRIPTION
Previously, the callback removal was postponed until .close() call, and
sometimes this .close() call cleared a file descriptor from a callback set
by another connection object (if the file desriptor was closed by psycopg2 when
an error occurred, and then opened again for a new connection).

The effect of this was, when making tens of parallel connections, an error in
one of them made another time out.

Now, if a psycopg2 error occurs, and the file descriptor has gone bad, the
callback is removed immediately, and the aiopg connection object 'forgets'
about this file descriptor (self._fileno = None), and doesn't try to remove
callbacks in .close().

If there were no errors, callbacks are still removed during .close() call.

Fixes #138.