### PR TITLE
Fixed connection to work under both windows and posix based systems

### DIFF
--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -141,7 +141,8 @@ class Connection:
                     if _is_bad_descriptor_error(os_exc):
                         with contextlib.suppress(OSError):
                             self._loop.remove_reader(self._fileno)
-                            # forget a bad file descriptor, don't try to touch it
+                            # forget a bad file descriptor, don't try to
+                            # touch it
                             self._fileno = None
 
             try:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -607,4 +607,3 @@ def test_remove_reader_from_dead_fd(connect):
     conn.close()
     assert not m_remove_reader.called
     old_remove_reader(fileno)
-


### PR DESCRIPTION
Also updated tests to always remove descriptors from event loop if closed. This is because the asyncio event loop under windows creates errors if the loop is run and there are closed file descriptors in the select. 

The reason that aiopg stopped working under windows (it did work until v11.0) was the recent introduction of the use of the fcntl function to determine if the filedescriptor had been closed. A more OS friendly poll on the socket has been used instead, to determine if the filedescriptor has been closed.

To run the tests under windows, the `pg_server` fixture had to be changed, as obviously docker is not available under windows. It was changed to run on a local database rather than a docker database, but these changes were not added to the pull request as they were a hack, and maybe not the way that developers would want to run the tests (they exist in a localtest branch on my fork).