### PR TITLE
Timeout on aquiring connection from pool

### DIFF
--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -4,6 +4,7 @@ import sys
 import warnings
 
 
+import async_timeout
 from psycopg2.extensions import TRANSACTION_STATUS_IDLE
 
 from .connection import connect, TIMEOUT
@@ -163,21 +164,23 @@ class Pool(asyncio.AbstractServer):
 
     @asyncio.coroutine
     def _acquire(self):
-        if self._closing:
-            raise RuntimeError("Cannot acquire connection after closing pool")
-        with (yield from self._cond):
-            while True:
-                yield from self._fill_free_pool(True)
-                if self._free:
-                    conn = self._free.popleft()
-                    assert not conn.closed, conn
-                    assert conn not in self._used, (conn, self._used)
-                    self._used.add(conn)
-                    if self._on_connect is not None:
-                        yield from self._on_connect(conn)
-                    return conn
-                else:
-                    yield from self._cond.wait()
+        with async_timeout.timeout(self._timeout, loop=self._loop):
+            if self._closing:
+                raise RuntimeError(
+                    "Cannot acquire connection after closing pool")
+            with (yield from self._cond):
+                while True:
+                    yield from self._fill_free_pool(True)
+                    if self._free:
+                        conn = self._free.popleft()
+                        assert not conn.closed, conn
+                        assert conn not in self._used, (conn, self._used)
+                        self._used.add(conn)
+                        if self._on_connect is not None:
+                            yield from self._on_connect(conn)
+                        return conn
+                    else:
+                        yield from self._cond.wait()
 
     @asyncio.coroutine
     def _fill_free_pool(self, override_min):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ import sys
 from setuptools import setup
 
 
-install_requires = ['psycopg2>=2.5.2']
+install_requires = [
+    'psycopg2>=2.5.2',
+    'async-timeout==1.1.0'
+]
 
 PY_VER = sys.version_info
 


### PR DESCRIPTION
This PR implements timeout on acquiring connection from pool using the [async-timeout](https://github.com/aio-libs/async-timeout) lib. (#130)