### PR TITLE
Add explicit code blocks for syntax highlighting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ asynchronous features of the Psycopg database driver.
 Example
 -------
 
-::
+.. code-block:: python
 
     import asyncio
     import aiopg
@@ -36,7 +36,7 @@ Example
 Example of SQLAlchemy optional integration
 ------------------------------------------
 
-::
+.. code-block:: python
 
    import asyncio
    from aiopg.sa import create_engine


### PR DESCRIPTION
This is mainly for Github, but should have no effect since the default is python anyway.