### PR TITLE
Enable syntax highlighting for README examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ asynchronous features of the Psycopg database driver.
 Example
 -------
 
-::
+.. code:: python
 
     import asyncio
     import aiopg
@@ -36,7 +36,7 @@ Example
 Example of SQLAlchemy optional integration
 ------------------------------------------
 
-::
+.. code:: python
 
    import asyncio
    from aiopg.sa import create_engine


### PR DESCRIPTION
GitHub supports syntax highlighting in `.rst` files with the `.. code:: <language>` mark-up. Use this to make the README.rst examples pretty.