### PR TITLE
Unnecessary None as second argument

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,7 +127,7 @@ highlight_language = 'python3'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
+on_rtd = os.environ.get('READTHEDOCS') == 'True'
 
 if on_rtd:
     html_theme = 'default'


### PR DESCRIPTION
By default dict.get() returns None, if the key you were searching for wasn't found. Therefore, you can remove None as second argument.