### PR TITLE
OperationalError during cancel() causes the pool to get blocked

### DIFF
--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -222,7 +222,11 @@ class Connection:
             self._waiter = create_future(self._loop)
             self._cancelling = True
             self._cancellation_waiter = self._waiter
-            self._conn.cancel()
+            try:
+                self._conn.cancel()
+            except psycopg2.OperationalError:
+                self._close()
+                return
             if not self._conn.isexecuting():
                 return
             try:


### PR DESCRIPTION
I've seen this occur a couple of times:
```
File "/usr/local/lib/python3.5/site-packages/aiopg/cursor.py", line 113, in execute
    yield from self._conn._poll(waiter, timeout)
  File "/usr/local/lib/python3.5/site-packages/aiopg/connection.py", line 239, in _poll
    yield from asyncio.shield(cancel(), loop=self._loop)
  File "/usr/local/lib/python3.5/asyncio/futures.py", line 361, in __iter__
    yield self  # This tells Task to wait for completion.
  File "/usr/local/lib/python3.5/asyncio/tasks.py", line 296, in _wakeup
    future.result()
  File "/usr/local/lib/python3.5/asyncio/futures.py", line 274, in result
    raise self._exception
  File "/usr/local/lib/python3.5/asyncio/tasks.py", line 239, in _step
    result = coro.send(None)
  File "/usr/local/lib/python3.5/site-packages/aiopg/connection.py", line 225, in cancel
    self._conn.cancel()
psycopg2.OperationalError: PQcancel() -- connect() failed: No route to host
```
And after that the connection seems to be unusable, This PR catches the OperationalError and treats it like a timeout by calling `close()`

Not sure how to write an integration test to trigger this