### PR TITLE
Pool connections recycling

### DIFF
--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -3,6 +3,7 @@ import contextlib
 import errno
 import select
 import sys
+import time
 import traceback
 import warnings
 import weakref
@@ -111,6 +112,7 @@ class Connection:
         assert self._conn.isexecuting(), "Is conn an async at all???"
         self._fileno = self._conn.fileno()
         self._timeout = timeout
+        self._last_usage = time.time()
         self._waiter = waiter
         self._writing = False
         self._cancelling = False
@@ -264,6 +266,7 @@ class Connection:
         psycopg in asynchronous mode.
 
         """
+        self._last_usage = time.time()
         coro = self._cursor(name=name, cursor_factory=cursor_factory,
                             scrollable=scrollable, withhold=withhold,
                             timeout=timeout)
@@ -491,6 +494,11 @@ class Connection:
     def timeout(self):
         """Return default timeout for connection operations."""
         return self._timeout
+
+    @property
+    def last_usage(self):
+        """Return time() when connection was used."""
+        return self._last_usage
 
     @property
     def echo(self):

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -3,7 +3,6 @@ import contextlib
 import errno
 import select
 import sys
-import time
 import traceback
 import warnings
 import weakref
@@ -112,7 +111,7 @@ class Connection:
         assert self._conn.isexecuting(), "Is conn an async at all???"
         self._fileno = self._conn.fileno()
         self._timeout = timeout
-        self._last_usage = time.time()
+        self._last_usage = self._loop.time()
         self._waiter = waiter
         self._writing = False
         self._cancelling = False
@@ -266,7 +265,7 @@ class Connection:
         psycopg in asynchronous mode.
 
         """
-        self._last_usage = time.time()
+        self._last_usage = self._loop.time()
         coro = self._cursor(name=name, cursor_factory=cursor_factory,
                             scrollable=scrollable, withhold=withhold,
                             timeout=timeout)

--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -191,7 +191,7 @@ class Pool(asyncio.AbstractServer):
             if conn.closed:
                 self._free.pop()
             elif self._recycle > -1 \
-                    and time.time() - conn.last_usage > self._recycle:
+                    and self._loop.time() - conn.last_usage > self._recycle:
                 conn.close()
                 self._free.pop()
             else:

--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -1,7 +1,6 @@
 import asyncio
 import collections
 import sys
-import time
 import warnings
 
 

--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -1,6 +1,7 @@
 import asyncio
 import collections
 import sys
+import time
 import warnings
 
 
@@ -17,12 +18,12 @@ PY_341 = sys.version_info >= (3, 4, 1)
 
 
 def create_pool(dsn=None, *, minsize=1, maxsize=10,
-                loop=None, timeout=TIMEOUT,
+                loop=None, timeout=TIMEOUT, recycle=-1,
                 enable_json=True, enable_hstore=True, enable_uuid=True,
                 echo=False, on_connect=None,
                 **kwargs):
     coro = _create_pool(dsn=dsn, minsize=minsize, maxsize=maxsize, loop=loop,
-                        timeout=timeout, enable_json=enable_json,
+                        timeout=timeout, recycle=recycle, enable_json=enable_json,
                         enable_hstore=enable_hstore, enable_uuid=enable_uuid,
                         echo=echo, on_connect=on_connect, **kwargs)
     return _PoolContextManager(coro)
@@ -30,7 +31,7 @@ def create_pool(dsn=None, *, minsize=1, maxsize=10,
 
 @asyncio.coroutine
 def _create_pool(dsn=None, *, minsize=1, maxsize=10,
-                 loop=None, timeout=TIMEOUT,
+                 loop=None, timeout=TIMEOUT, recycle=-1,
                  enable_json=True, enable_hstore=True, enable_uuid=True,
                  echo=False, on_connect=None,
                  **kwargs):
@@ -40,7 +41,7 @@ def _create_pool(dsn=None, *, minsize=1, maxsize=10,
     pool = Pool(dsn, minsize, maxsize, loop, timeout,
                 enable_json=enable_json, enable_hstore=enable_hstore,
                 enable_uuid=enable_uuid, echo=echo, on_connect=on_connect,
-                **kwargs)
+                recycle=recycle, **kwargs)
     if minsize > 0:
         with (yield from pool._cond):
             yield from pool._fill_free_pool(False)
@@ -52,7 +53,7 @@ class Pool(asyncio.AbstractServer):
 
     def __init__(self, dsn, minsize, maxsize, loop, timeout, *,
                  enable_json, enable_hstore, enable_uuid, echo,
-                 on_connect, **kwargs):
+                 on_connect, recycle, **kwargs):
         if minsize < 0:
             raise ValueError("minsize should be zero or greater")
         if maxsize < minsize and maxsize != 0:
@@ -61,6 +62,7 @@ class Pool(asyncio.AbstractServer):
         self._minsize = minsize
         self._loop = loop
         self._timeout = timeout
+        self._recycle = recycle
         self._enable_json = enable_json
         self._enable_hstore = enable_hstore
         self._enable_uuid = enable_uuid
@@ -186,6 +188,9 @@ class Pool(asyncio.AbstractServer):
         while n < free:
             conn = self._free[-1]
             if conn.closed:
+                self._free.pop()
+            elif self._recycle > -1 and time.time() - conn.last_usage > self._recycle:
+                conn.close()
                 self._free.pop()
             else:
                 self._free.rotate()

--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -17,12 +17,12 @@ PY_341 = sys.version_info >= (3, 4, 1)
 
 
 def create_pool(dsn=None, *, minsize=1, maxsize=10,
-                loop=None, timeout=TIMEOUT, recycle=-1,
+                loop=None, timeout=TIMEOUT, pool_recycle=-1,
                 enable_json=True, enable_hstore=True, enable_uuid=True,
                 echo=False, on_connect=None,
                 **kwargs):
     coro = _create_pool(dsn=dsn, minsize=minsize, maxsize=maxsize, loop=loop,
-                        timeout=timeout, recycle=recycle,
+                        timeout=timeout, pool_recycle=pool_recycle,
                         enable_json=enable_json, enable_hstore=enable_hstore,
                         enable_uuid=enable_uuid, echo=echo,
                         on_connect=on_connect, **kwargs)
@@ -31,7 +31,7 @@ def create_pool(dsn=None, *, minsize=1, maxsize=10,
 
 @asyncio.coroutine
 def _create_pool(dsn=None, *, minsize=1, maxsize=10,
-                 loop=None, timeout=TIMEOUT, recycle=-1,
+                 loop=None, timeout=TIMEOUT, pool_recycle=-1,
                  enable_json=True, enable_hstore=True, enable_uuid=True,
                  echo=False, on_connect=None,
                  **kwargs):
@@ -41,7 +41,7 @@ def _create_pool(dsn=None, *, minsize=1, maxsize=10,
     pool = Pool(dsn, minsize, maxsize, loop, timeout,
                 enable_json=enable_json, enable_hstore=enable_hstore,
                 enable_uuid=enable_uuid, echo=echo, on_connect=on_connect,
-                recycle=recycle, **kwargs)
+                pool_recycle=pool_recycle, **kwargs)
     if minsize > 0:
         with (yield from pool._cond):
             yield from pool._fill_free_pool(False)
@@ -53,7 +53,7 @@ class Pool(asyncio.AbstractServer):
 
     def __init__(self, dsn, minsize, maxsize, loop, timeout, *,
                  enable_json, enable_hstore, enable_uuid, echo,
-                 on_connect, recycle, **kwargs):
+                 on_connect, pool_recycle, **kwargs):
         if minsize < 0:
             raise ValueError("minsize should be zero or greater")
         if maxsize < minsize and maxsize != 0:
@@ -62,7 +62,7 @@ class Pool(asyncio.AbstractServer):
         self._minsize = minsize
         self._loop = loop
         self._timeout = timeout
-        self._recycle = recycle
+        self._recycle = pool_recycle
         self._enable_json = enable_json
         self._enable_hstore = enable_hstore
         self._enable_uuid = enable_uuid

--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -23,9 +23,10 @@ def create_pool(dsn=None, *, minsize=1, maxsize=10,
                 echo=False, on_connect=None,
                 **kwargs):
     coro = _create_pool(dsn=dsn, minsize=minsize, maxsize=maxsize, loop=loop,
-                        timeout=timeout, recycle=recycle, enable_json=enable_json,
-                        enable_hstore=enable_hstore, enable_uuid=enable_uuid,
-                        echo=echo, on_connect=on_connect, **kwargs)
+                        timeout=timeout, recycle=recycle,
+                        enable_json=enable_json, enable_hstore=enable_hstore,
+                        enable_uuid=enable_uuid, echo=echo,
+                        on_connect=on_connect, **kwargs)
     return _PoolContextManager(coro)
 
 
@@ -189,7 +190,8 @@ class Pool(asyncio.AbstractServer):
             conn = self._free[-1]
             if conn.closed:
                 self._free.pop()
-            elif self._recycle > -1 and time.time() - conn.last_usage > self._recycle:
+            elif self._recycle > -1 \
+                    and time.time() - conn.last_usage > self._recycle:
                 conn.close()
                 self._free.pop()
             else:

--- a/aiopg/sa/engine.py
+++ b/aiopg/sa/engine.py
@@ -44,7 +44,7 @@ _dialect._has_native_hstore = True
 
 
 def create_engine(dsn=None, *, minsize=1, maxsize=10, loop=None,
-                  dialect=_dialect, timeout=TIMEOUT, **kwargs):
+                  dialect=_dialect, timeout=TIMEOUT, recycle=-1, **kwargs):
     """A coroutine for Engine creation.
 
     Returns Engine instance with embedded connection pool.
@@ -54,17 +54,18 @@ def create_engine(dsn=None, *, minsize=1, maxsize=10, loop=None,
 
     coro = _create_engine(dsn=dsn, minsize=minsize, maxsize=maxsize,
                           loop=loop, dialect=dialect, timeout=timeout,
-                          **kwargs)
+                          recycle=recycle, **kwargs)
     return _EngineContextManager(coro)
 
 
 @asyncio.coroutine
 def _create_engine(dsn=None, *, minsize=1, maxsize=10, loop=None,
-                   dialect=_dialect, timeout=TIMEOUT, **kwargs):
+                   dialect=_dialect, timeout=TIMEOUT, recycle=-1, **kwargs):
     if loop is None:
         loop = asyncio.get_event_loop()
     pool = yield from aiopg.create_pool(dsn, minsize=minsize, maxsize=maxsize,
-                                        loop=loop, timeout=timeout, **kwargs)
+                                        loop=loop, timeout=timeout, recycle=recycle,
+                                        **kwargs)
     conn = yield from pool.acquire()
     try:
         real_dsn = conn.dsn

--- a/aiopg/sa/engine.py
+++ b/aiopg/sa/engine.py
@@ -44,7 +44,8 @@ _dialect._has_native_hstore = True
 
 
 def create_engine(dsn=None, *, minsize=1, maxsize=10, loop=None,
-                  dialect=_dialect, timeout=TIMEOUT, recycle=-1, **kwargs):
+                  dialect=_dialect, timeout=TIMEOUT, pool_recycle=-1,
+                  **kwargs):
     """A coroutine for Engine creation.
 
     Returns Engine instance with embedded connection pool.
@@ -54,18 +55,19 @@ def create_engine(dsn=None, *, minsize=1, maxsize=10, loop=None,
 
     coro = _create_engine(dsn=dsn, minsize=minsize, maxsize=maxsize,
                           loop=loop, dialect=dialect, timeout=timeout,
-                          recycle=recycle, **kwargs)
+                          pool_recycle=pool_recycle, **kwargs)
     return _EngineContextManager(coro)
 
 
 @asyncio.coroutine
 def _create_engine(dsn=None, *, minsize=1, maxsize=10, loop=None,
-                   dialect=_dialect, timeout=TIMEOUT, recycle=-1, **kwargs):
+                   dialect=_dialect, timeout=TIMEOUT, pool_recycle=-1,
+                   **kwargs):
     if loop is None:
         loop = asyncio.get_event_loop()
     pool = yield from aiopg.create_pool(dsn, minsize=minsize, maxsize=maxsize,
                                         loop=loop, timeout=timeout,
-                                        recycle=recycle, **kwargs)
+                                        pool_recycle=pool_recycle, **kwargs)
     conn = yield from pool.acquire()
     try:
         real_dsn = conn.dsn

--- a/aiopg/sa/engine.py
+++ b/aiopg/sa/engine.py
@@ -64,8 +64,8 @@ def _create_engine(dsn=None, *, minsize=1, maxsize=10, loop=None,
     if loop is None:
         loop = asyncio.get_event_loop()
     pool = yield from aiopg.create_pool(dsn, minsize=minsize, maxsize=maxsize,
-                                        loop=loop, timeout=timeout, recycle=recycle,
-                                        **kwargs)
+                                        loop=loop, timeout=timeout,
+                                        recycle=recycle, **kwargs)
     conn = yield from pool.acquire()
     try:
         real_dsn = conn.dsn

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -509,7 +509,7 @@ def test_connection_in_good_state_after_timeout(create_pool):
 def test_pool_with_connection_recycling(create_pool, loop):
     pool = yield from create_pool(minsize=1,
                                   maxsize=1,
-                                  recycle=3)
+                                  pool_recycle=3)
     with (yield from pool) as conn:
         cur = yield from conn.cursor()
         yield from cur.execute('SELECT 1;')


### PR DESCRIPTION
Related to issue: https://github.com/aio-libs/aiopg/issues/372

Now you can do simply:
```python
db_engine = await aiopg.sa.create_engine(..., recycle=300)
```

... and then all connections which were unused last `300` seconds - will be automatically closed and re-established.