### PR TITLE
Update psycopg version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pytest-sugar==0.9.0
 pytest-timeout==1.2.1
 sphinxcontrib-asyncio==0.2.0
 sqlalchemy==1.2.0
-psycopg2==2.6.2
+psycopg2==2.7.3.2

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup
 
 
-install_requires = ['psycopg2>=2.5.2']
+install_requires = ['psycopg2>=2.7.0']
 
 PY_VER = sys.version_info
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -209,11 +209,11 @@ def test_autocommit(connect):
 def test_isolation_level(connect):
     conn = yield from connect()
 
-    assert 0 == conn.isolation_level
+    assert psycopg2.extensions.ISOLATION_LEVEL_DEFAULT == conn.isolation_level
     with pytest.raises(psycopg2.ProgrammingError):
         yield from conn.set_isolation_level(1)
 
-    assert 0 == conn.isolation_level
+    assert psycopg2.extensions.ISOLATION_LEVEL_DEFAULT == conn.isolation_level
 
 
 @asyncio.coroutine

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -621,7 +621,7 @@ def test_close_cursor_on_timeout_error(connect):
 @asyncio.coroutine
 def test_issue_111_crash_on_connect_error(loop):
     import aiopg.connection
-    with pytest.raises(psycopg2.OperationalError):
+    with pytest.raises(psycopg2.ProgrammingError):
         yield from aiopg.connection.connect('baddsn:1', loop=loop)
 
 

--- a/tests/test_sa_engine.py
+++ b/tests/test_sa_engine.py
@@ -1,5 +1,6 @@
 import asyncio
 from aiopg.connection import TIMEOUT
+from psycopg2.extensions import parse_dsn
 
 import pytest
 sa = pytest.importorskip("aiopg.sa")  # noqa
@@ -39,10 +40,11 @@ def test_driver(engine):
 
 
 def test_dsn(engine, pg_params):
-    pg_params['password'] = 'x' * len(pg_params['password'])
-    dsn = ('dbname={database} user={user} password={password} '
-           'host={host} port={port}').format_map(pg_params)
-    assert dsn == engine.dsn
+    pg_params['password'] = 'xxx'
+    params = pg_params.copy()
+    params['dbname'] = params.pop('database')
+    params['port'] = str(params['port'])
+    assert parse_dsn(engine.dsn) == params
 
 
 def test_minsize(engine):

--- a/tests/test_sa_engine.py
+++ b/tests/test_sa_engine.py
@@ -40,8 +40,8 @@ def test_driver(engine):
 
 
 def test_dsn(engine, pg_params):
-    pg_params['password'] = 'xxx'
     params = pg_params.copy()
+    params['password'] = 'xxx'
     params['dbname'] = params.pop('database')
     params['port'] = str(params['port'])
     assert parse_dsn(engine.dsn) == params


### PR DESCRIPTION
Upgrade to psycopg2 fixes our CI:
```bash
  Downloading psycopg2-2.6.2.tar.gz (376kB)
    100% |████████████████████████████████| 378kB 3.4MB/s 
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    Error: could not determine PostgreSQL version from '10.1'
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-6vyhk2zm/psycopg2/
The command "pip install -Ur requirements.txt" failed and exited with 1 during .
```

See also https://github.com/psycopg/psycopg2/issues/594