### PR TITLE
refactor one connect one cursore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,11 @@ vtest: flake
 	pytest tests
 
 cov cover coverage: flake
-	py.test --cov=aiopg --cov-report=html --cov-report=term tests
+	py.test -svvv -rs --cov=aiopg --cov-report=html --cov-report=term tests
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 cov-ci: flake
-	py.test -v --cov --cov-report=term tests --pg_tag all
+	py.test -svvv -rs --cov --cov-report=term tests --pg_tag all
 
 clean:
 	find . -name __pycache__ |xargs rm -rf

--- a/aiopg/__init__.py
+++ b/aiopg/__init__.py
@@ -1,11 +1,19 @@
 import re
 import sys
+import warnings
 from collections import namedtuple
 
 from .connection import connect, Connection, TIMEOUT as DEFAULT_TIMEOUT
 from .cursor import Cursor
 from .pool import create_pool, Pool
 from .transaction import IsolationLevel, Transaction
+
+warnings.filterwarnings(
+    'always', '.*',
+    category=ResourceWarning,
+    module=r'aiopg(\.\w+)+',
+    append=False
+)
 
 __all__ = ('connect', 'create_pool', 'Connection', 'Cursor', 'Pool',
            'version', 'version_info', 'DEFAULT_TIMEOUT', 'IsolationLevel',

--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -16,8 +16,6 @@ class Cursor:
         self._echo = echo
         self._transaction = Transaction(self, IsolationLevel.repeatable_read)
 
-        conn.cursor_created(self)
-
     @property
     def echo(self):
         """Return echo mode status."""
@@ -52,7 +50,6 @@ class Cursor:
         """Close the cursor now."""
         if not self.closed:
             self._impl.close()
-            self._conn.cursor_closed(self)
 
     @property
     def closed(self):
@@ -393,3 +390,18 @@ class Cursor:
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         self.close()
         return
+
+    def __repr__(self):
+        msg = (
+            '<'
+            '{module_name}::{class_name} '
+            'name={name}, '
+            'closed={closed}'
+            '>'
+        )
+        return msg.format(
+            module_name=type(self).__module__,
+            class_name=type(self).__name__,
+            name=self.name,
+            closed=self.closed
+        )

--- a/tests/pep492/test_async_await.py
+++ b/tests/pep492/test_async_await.py
@@ -1,6 +1,8 @@
 import asyncio
-import pytest
+
 import psycopg2
+import pytest
+
 import aiopg
 import aiopg.sa
 from aiopg.sa import SAConnection
@@ -12,7 +14,7 @@ async def test_cursor_await(make_connection):
     cursor = await conn.cursor()
     await cursor.execute('SELECT 42;')
     resp = await cursor.fetchone()
-    assert resp == (42, )
+    assert resp == (42,)
     cursor.close()
 
 
@@ -21,7 +23,7 @@ async def test_connect_context_manager(loop, pg_params):
         cursor = await conn.cursor()
         await cursor.execute('SELECT 42')
         resp = await cursor.fetchone()
-        assert resp == (42, )
+        assert resp == (42,)
         cursor.close()
     assert conn.closed
 
@@ -33,7 +35,7 @@ async def test_connection_context_manager(make_connection):
         cursor = await conn.cursor()
         await cursor.execute('SELECT 42;')
         resp = await cursor.fetchone()
-        assert resp == (42, )
+        assert resp == (42,)
         cursor.close()
     assert conn.closed
 
@@ -44,18 +46,10 @@ async def test_cursor_create_with_context_manager(make_connection):
     async with conn.cursor() as cursor:
         await cursor.execute('SELECT 42;')
         resp = await cursor.fetchone()
-        assert resp == (42, )
+        assert resp == (42,)
         assert not cursor.closed
 
     assert cursor.closed
-
-
-async def test_two_cursor_create_with_context_manager(make_connection):
-    conn = await make_connection()
-
-    async with conn.cursor() as cursor1, conn.cursor() as cursor2:
-        assert cursor1.closed
-        assert not cursor2.closed
 
 
 async def test_pool_context_manager_timeout(pg_params, loop):
@@ -75,7 +69,7 @@ async def test_pool_context_manager_timeout(pg_params, loop):
         with cursor_ctx as cursor:
             resp = await cursor.execute('SELECT 42;')
             resp = await cursor.fetchone()
-            assert resp == (42, )
+            assert resp == (42,)
 
     assert cursor.closed
     assert pool.closed
@@ -89,7 +83,7 @@ async def test_cursor_with_context_manager(make_connection):
     assert not cursor.closed
     async with cursor:
         resp = await cursor.fetchone()
-        assert resp == (42, )
+        assert resp == (42,)
     assert cursor.closed
 
 
@@ -112,7 +106,7 @@ async def test_pool_context_manager(pg_params, loop):
         async with conn.cursor() as cursor:
             await cursor.execute('SELECT 42;')
             resp = await cursor.fetchone()
-            assert resp == (42, )
+            assert resp == (42,)
         pool.release(conn)
     assert cursor.closed
     assert pool.closed
@@ -124,7 +118,7 @@ async def test_create_pool_context_manager(pg_params, loop):
             async with conn.cursor() as cursor:
                 await cursor.execute('SELECT 42;')
                 resp = await cursor.fetchone()
-                assert resp == (42, )
+                assert resp == (42,)
 
     assert cursor.closed
     assert conn.closed
@@ -140,7 +134,7 @@ async def test_cursor_aiter(make_connection):
         await cursor.execute('SELECT generate_series(1, 5);')
         async for v in cursor:
             result.append(v)
-        assert result == [(1,), (2, ), (3, ), (4, ), (5, )]
+        assert result == [(1,), (2,), (3,), (4,), (5,)]
         cursor.close()
     assert conn.closed
 
@@ -169,7 +163,7 @@ async def test_result_proxy_aiter(pg_params, loop):
             async with conn.execute(sql) as cursor:
                 async for v in cursor:
                     result.append(v)
-                assert result == [(1,), (2, ), (3, ), (4, ), (5, )]
+                assert result == [(1,), (2,), (3,), (4,), (5,)]
             assert cursor.closed
     assert conn.closed
 
@@ -184,7 +178,7 @@ async def test_transaction_context_manager(pg_params, loop):
                     async for v in cursor:
                         result.append(v)
                     assert tr.is_active
-                assert result == [(1,), (2, ), (3, ), (4, ), (5, )]
+                assert result == [(1,), (2,), (3,), (4,), (5,)]
                 assert cursor.closed
             assert not tr.is_active
 
@@ -243,7 +237,7 @@ async def test_transaction_context_manager_nested_commit(pg_params, loop):
                             result.append(v)
                         assert tr1.is_active
                         assert tr2.is_active
-                    assert result == [(1,), (2, ), (3, ), (4, ), (5, )]
+                    assert result == [(1,), (2,), (3,), (4,), (5,)]
                     assert cursor.closed
                 assert not tr2.is_active
 
@@ -267,5 +261,5 @@ async def test_sa_connection_execute(pg_params, loop):
         async with engine.acquire() as conn:
             async for value in conn.execute(sql):
                 result.append(value)
-            assert result == [(1,), (2, ), (3, ), (4, ), (5, )]
+            assert result == [(1,), (2,), (3,), (4,), (5,)]
     assert conn.closed

--- a/tests/pep492/test_sa_priority_name.py
+++ b/tests/pep492/test_sa_priority_name.py
@@ -28,7 +28,7 @@ def connect(make_sa_connection, loop):
 
 async def test_priority_name(connect):
     await connect.execute(tbl.insert().values(id='test_id', name='test_name'))
-    row = await (await connect.execute(tbl.select())).fetchone()
+    row = await (await connect.execute(tbl.select())).first()
     assert row.name == 'test_name'
     assert row.id == 'test_id'
 
@@ -39,7 +39,7 @@ async def test_priority_name_label(connect):
         [tbl.c.name.label('test_label_name'), tbl.c.id]
     )
     query = query.select_from(tbl)
-    row = await (await connect.execute(query)).fetchone()
+    row = await (await connect.execute(query)).first()
     assert row.test_label_name == 'test_name'
     assert row.id == 'test_id'
 
@@ -50,7 +50,7 @@ async def test_priority_name_and_label(connect):
         [tbl.c.name.label('test_label_name'), tbl.c.name, tbl.c.id]
     )
     query = query.select_from(tbl)
-    row = await (await connect.execute(query)).fetchone()
+    row = await (await connect.execute(query)).first()
     assert row.test_label_name == 'test_name'
     assert row.name == 'test_name'
     assert row.id == 'test_id'
@@ -60,7 +60,7 @@ async def test_priority_name_all_get(connect):
     await connect.execute(tbl.insert().values(id='test_id', name='test_name'))
     query = sa.select([tbl.c.name])
     query = query.select_from(tbl)
-    row = await (await connect.execute(query)).fetchone()
+    row = await (await connect.execute(query)).first()
     assert row.name == 'test_name'
     assert row['name'] == 'test_name'
     assert row[0] == 'test_name'

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -4,72 +4,77 @@ import time
 import psycopg2
 import psycopg2.tz
 import pytest
+
 from aiopg.connection import TIMEOUT
 
 
 @pytest.fixture
 def connect(make_connection):
-
     async def go(**kwargs):
         conn = await make_connection(**kwargs)
-        cur = await conn.cursor()
-        await cur.execute("DROP TABLE IF EXISTS tbl")
-        await cur.execute("CREATE TABLE tbl (id int, name varchar(255))")
-        for i in [(1, 'a'), (2, 'b'), (3, 'c')]:
-            await cur.execute("INSERT INTO tbl VALUES(%s, %s)", i)
-        await cur.execute("DROP TABLE IF EXISTS tbl2")
-        await cur.execute("""CREATE TABLE tbl2
-                                  (id int, name varchar(255))
-                                  WITH OIDS""")
-        await cur.execute("DROP FUNCTION IF EXISTS inc(val integer)")
-        await cur.execute("""CREATE FUNCTION inc(val integer)
-                                  RETURNS integer AS $$
-                                  BEGIN
-                                  RETURN val + 1;
-                                  END; $$
-                                  LANGUAGE PLPGSQL;""")
+        async with conn.cursor() as cur:
+            await cur.execute("DROP TABLE IF EXISTS tbl")
+            await cur.execute("CREATE TABLE tbl (id int, name varchar(255))")
+            for i in [(1, 'a'), (2, 'b'), (3, 'c')]:
+                await cur.execute("INSERT INTO tbl VALUES(%s, %s)", i)
+            await cur.execute("DROP TABLE IF EXISTS tbl2")
+            await cur.execute("""CREATE TABLE tbl2
+                                      (id int, name varchar(255))
+                                      WITH OIDS""")
+            await cur.execute("DROP FUNCTION IF EXISTS inc(val integer)")
+            await cur.execute("""CREATE FUNCTION inc(val integer)
+                                      RETURNS integer AS $$
+                                      BEGIN
+                                      RETURN val + 1;
+                                      END; $$
+                                      LANGUAGE PLPGSQL;""")
         return conn
 
     return go
 
 
-async def test_description(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    assert cur.description is None
-    await cur.execute('SELECT * from tbl;')
+@pytest.yield_fixture
+def cursor(connect, loop):
+    async def go():
+        return await (await connect()).cursor()
 
-    assert len(cur.description) == 2, \
-        'cursor.description describes too many columns'
-
-    assert len(cur.description[0]) == 7, \
-        'cursor.description[x] tuples must have 7 elements'
-
-    assert cur.description[0][0].lower() == 'id', \
-        'cursor.description[x][0] must return column name'
-
-    assert cur.description[1][0].lower() == 'name', \
-        'cursor.description[x][0] must return column name'
-
-    # Make sure self.description gets reset, cursor should be
-    # set to None in case of none resulting queries like DDL
-    await cur.execute('DROP TABLE IF EXISTS foobar;')
-    assert cur.description is None
-
-
-async def test_raw(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    assert cur._impl is cur.raw
-
-
-async def test_close(connect):
-    conn = await connect()
-    cur = await conn.cursor()
+    cur = loop.run_until_complete(go())
+    yield cur
     cur.close()
-    assert cur.closed
+
+
+async def test_description(cursor):
+    async with cursor as cur:
+        assert cur.description is None
+        await cur.execute('SELECT * from tbl;')
+
+        assert len(cur.description) == 2, \
+            'cursor.description describes too many columns'
+
+        assert len(cur.description[0]) == 7, \
+            'cursor.description[x] tuples must have 7 elements'
+
+        assert cur.description[0][0].lower() == 'id', \
+            'cursor.description[x][0] must return column name'
+
+        assert cur.description[1][0].lower() == 'name', \
+            'cursor.description[x][0] must return column name'
+
+        # Make sure self.description gets reset, cursor should be
+        # set to None in case of none resulting queries like DDL
+        await cur.execute('DROP TABLE IF EXISTS foobar;')
+        assert cur.description is None
+
+
+async def test_raw(cursor):
+    assert cursor._impl is cursor.raw
+
+
+async def test_close(cursor):
+    cursor.close()
+    assert cursor.closed
     with pytest.raises(psycopg2.InterfaceError):
-        await cur.execute('SELECT 1')
+        await cursor.execute('SELECT 1')
 
 
 async def test_close_twice(connect):
@@ -89,153 +94,119 @@ async def test_connection(connect):
     assert cur.connection is conn
 
 
-async def test_name(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    assert cur.name is None
+async def test_name(cursor):
+    assert cursor.name is None
 
 
-async def test_scrollable(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    assert cur.scrollable is None
+async def test_scrollable(cursor):
+    assert cursor.scrollable is None
     with pytest.raises(psycopg2.ProgrammingError):
-        cur.scrollable = True
+        cursor.scrollable = True
 
 
-async def test_withhold(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    assert not cur.withhold
+async def test_withhold(cursor):
+    assert not cursor.withhold
     with pytest.raises(psycopg2.ProgrammingError):
-        cur.withhold = True
-    assert not cur.withhold
+        cursor.withhold = True
+    assert not cursor.withhold
 
 
-async def test_execute(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    await cur.execute('SELECT 1')
-    ret = await cur.fetchone()
+async def test_execute(cursor):
+    await cursor.execute('SELECT 1')
+    ret = await cursor.fetchone()
     assert (1,) == ret
 
 
-async def test_executemany(connect):
-    conn = await connect()
-    cur = await conn.cursor()
+async def test_executemany(cursor):
     with pytest.raises(psycopg2.ProgrammingError):
-        await cur.executemany('SELECT %s', ['1', '2'])
+        await cursor.executemany('SELECT %s', ['1', '2'])
 
 
-async def test_mogrify(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    ret = await cur.mogrify('SELECT %s', ['1'])
+async def test_mogrify(cursor):
+    ret = await cursor.mogrify('SELECT %s', ['1'])
     assert b"SELECT '1'" == ret
 
 
-async def test_setinputsizes(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    await cur.setinputsizes(10)
+async def test_setinputsizes(cursor):
+    await cursor.setinputsizes(10)
 
 
-async def test_fetchmany(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    await cur.execute('SELECT * from tbl;')
-    ret = await cur.fetchmany()
+async def test_fetchmany(cursor):
+    await cursor.execute('SELECT * from tbl;')
+    ret = await cursor.fetchmany()
     assert [(1, 'a')] == ret
 
-    await cur.execute('SELECT * from tbl;')
-    ret = await cur.fetchmany(2)
+    await cursor.execute('SELECT * from tbl;')
+    ret = await cursor.fetchmany(2)
     assert [(1, 'a'), (2, 'b')] == ret
 
 
-async def test_fetchall(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    await cur.execute('SELECT * from tbl;')
-    ret = await cur.fetchall()
+async def test_fetchall(cursor):
+    await cursor.execute('SELECT * from tbl;')
+    ret = await cursor.fetchall()
     assert [(1, 'a'), (2, 'b'), (3, 'c')] == ret
 
 
-async def test_scroll(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    await cur.execute('SELECT * from tbl;')
-    await cur.scroll(1)
-    ret = await cur.fetchone()
+async def test_scroll(cursor):
+    await cursor.execute('SELECT * from tbl;')
+    await cursor.scroll(1)
+    ret = await cursor.fetchone()
     assert (2, 'b') == ret
 
 
-async def test_arraysize(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    assert 1 == cur.arraysize
+async def test_arraysize(cursor):
+    assert 1 == cursor.arraysize
 
-    cur.arraysize = 10
-    assert 10 == cur.arraysize
+    cursor.arraysize = 10
+    assert 10 == cursor.arraysize
 
 
-async def test_itersize(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    assert 2000 == cur.itersize
+async def test_itersize(cursor):
+    assert 2000 == cursor.itersize
 
-    cur.itersize = 10
-    assert 10 == cur.itersize
+    cursor.itersize = 10
+    assert 10 == cursor.itersize
 
 
-async def test_rows(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    await cur.execute('SELECT * from tbl')
-    assert 3 == cur.rowcount
-    assert 0 == cur.rownumber
-    await cur.fetchone()
-    assert 1 == cur.rownumber
+async def test_rows(cursor):
+    await cursor.execute('SELECT * from tbl')
+    assert 3 == cursor.rowcount
+    assert 0 == cursor.rownumber
+    await cursor.fetchone()
+    assert 1 == cursor.rownumber
 
-    assert 0 == cur.lastrowid
-    await cur.execute('INSERT INTO tbl2 VALUES (%s, %s)',
-                      (4, 'd'))
-    assert 0 != cur.lastrowid
-
-
-async def test_query(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    await cur.execute('SELECT 1')
-    assert b'SELECT 1' == cur.query
+    assert 0 == cursor.lastrowid
+    await cursor.execute(
+        'INSERT INTO tbl2 VALUES (%s, %s)',
+        (4, 'd')
+    )
+    assert 0 != cursor.lastrowid
 
 
-async def test_statusmessage(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    await cur.execute('SELECT 1')
-    assert 'SELECT 1' == cur.statusmessage
+async def test_query(cursor):
+    await cursor.execute('SELECT 1')
+    assert b'SELECT 1' == cursor.query
 
 
-async def test_tzinfo_factory(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    assert psycopg2.tz.FixedOffsetTimezone is cur.tzinfo_factory
-
-    cur.tzinfo_factory = psycopg2.tz.LocalTimezone
-    assert psycopg2.tz.LocalTimezone is cur.tzinfo_factory
+async def test_statusmessage(cursor):
+    await cursor.execute('SELECT 1')
+    assert 'SELECT 1' == cursor.statusmessage
 
 
-async def test_nextset(connect):
-    conn = await connect()
-    cur = await conn.cursor()
+async def test_tzinfo_factory(cursor):
+    assert psycopg2.tz.FixedOffsetTimezone is cursor.tzinfo_factory
+
+    cursor.tzinfo_factory = psycopg2.tz.LocalTimezone
+    assert psycopg2.tz.LocalTimezone is cursor.tzinfo_factory
+
+
+async def test_nextset(cursor):
     with pytest.raises(psycopg2.NotSupportedError):
-        await cur.nextset()
+        await cursor.nextset()
 
 
-async def test_setoutputsize(connect):
-    conn = await connect()
-    cur = await conn.cursor()
-    await cur.setoutputsize(4, 1)
+async def test_setoutputsize(cursor):
+    await cursor.setoutputsize(4, 1)
 
 
 async def test_copy_family(connect):
@@ -337,8 +308,12 @@ async def test_iter(connect):
     conn = await connect()
     cur = await conn.cursor()
     await cur.execute("SELECT * FROM tbl")
+    rows = []
+    async for r in cur:
+        rows.append(r)
+
     data = [(1, 'a'), (2, 'b'), (3, 'c')]
-    for item, tst in zip(cur, data):
+    for item, tst in zip(rows, data):
         assert item == tst
 
 

--- a/tests/test_sa_connection.py
+++ b/tests/test_sa_connection.py
@@ -6,7 +6,7 @@ import pytest
 sa = pytest.importorskip("aiopg.sa")  # noqa
 
 
-from sqlalchemy import MetaData, Table, Column, Integer, String
+from sqlalchemy import MetaData, Table, Column, Integer, String, select, func
 from sqlalchemy.schema import DropTable, CreateTable
 
 import psycopg2
@@ -122,7 +122,8 @@ async def test_execute_sa_insert_positional_params(connect):
 
 async def test_scalar(connect):
     conn = await connect()
-    res = await conn.scalar(tbl.count())
+    tbl.count
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 1, res
 
 

--- a/tests/test_sa_cursor.py
+++ b/tests/test_sa_cursor.py
@@ -1,0 +1,94 @@
+import warnings
+
+import pytest
+import sqlalchemy as sa
+
+meta = sa.MetaData()
+tbl = sa.Table(
+    'sa_tbl5', meta,
+    sa.Column('ID', sa.String, primary_key=True, key='id'),
+    sa.Column('Name', sa.String(255), key='name'),
+)
+
+
+@pytest.fixture
+def connect(make_sa_connection, loop):
+    async def start():
+        conn = await make_sa_connection()
+        await conn.execute('DROP TABLE IF EXISTS sa_tbl5')
+        await conn.execute(
+            'CREATE TABLE sa_tbl5 ('
+            '"ID" VARCHAR(255) NOT NULL, '
+            '"Name" VARCHAR(255), '
+            'PRIMARY KEY ("ID"))'
+        )
+
+        await conn.execute(
+            tbl.insert().values(id='test1', name='test_name'))
+        await conn.execute(
+            tbl.insert().values(id='test2', name='test_name'))
+        await conn.execute(
+            tbl.insert().values(id='test3', name='test_name'))
+
+        return conn
+
+    return loop.run_until_complete(start())
+
+
+async def test_insert(connect):
+    await connect.execute(tbl.insert().values(id='test-4', name='test_name'))
+    await connect.execute(tbl.insert().values(id='test-5', name='test_name'))
+    assert 5 == len(await (await connect.execute(tbl.select())).fetchall())
+
+
+async def test_insert_make_engine(make_engine, connect):
+    engine = await make_engine()
+    async with engine.acquire() as conn:
+        assert conn._cursor is None
+
+        await conn.execute(tbl.insert().values(id='test-4', name='test_name'))
+        assert conn._cursor.closed is True
+
+        resp = await conn.execute(tbl.select())
+        assert resp.cursor.closed is False
+        assert conn._cursor.closed is False
+
+        await conn.execute(tbl.insert().values(id='test-5', name='test_name'))
+        assert conn._cursor.closed is True
+
+        resp = await conn.execute(tbl.select())
+        assert resp.cursor.closed is False
+
+    assert conn._cursor.closed is True
+
+    assert conn.closed == 0
+
+    assert 5 == len(await (await connect.execute(tbl.select())).fetchall())
+
+
+async def test_two_cursor_create_context_manager(make_connection):
+    conn = await make_connection()
+
+    error_ms = (
+        'You can only have one cursor per connection. '
+        'The cursor for connection will be closed forcibly'
+        ' {!r}.'
+    )
+
+    with warnings.catch_warnings(record=True) as wars:
+        warnings.simplefilter("always")
+        async with conn.cursor() as cur:
+            error_ms = error_ms.format(conn)
+            assert cur.closed is False
+
+            async with conn.cursor() as cur2:
+                assert cur.closed is True
+                assert cur2.closed is False
+
+            assert len(wars) == 1
+            war = wars.pop()
+            assert issubclass(war.category, ResourceWarning)
+            assert str(war.message) == error_ms
+            assert cur2.closed is True
+
+    assert cur.closed is True

--- a/tests/test_sa_transaction.py
+++ b/tests/test_sa_transaction.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 sa = pytest.importorskip("aiopg.sa")  # noqa
 
-from sqlalchemy import MetaData, Table, Column, Integer, String
+from sqlalchemy import MetaData, Table, Column, Integer, String, select, func
 
 meta = MetaData()
 tbl = Table('sa_tbl2', meta,
@@ -48,12 +48,12 @@ def xa_connect(connect):
 async def test_without_transactions(connect):
     conn1 = await connect()
     conn2 = await connect()
-    res1 = await conn1.scalar(tbl.count())
+    res1 = await conn1.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res1
 
     await conn2.execute(tbl.delete())
 
-    res2 = await conn1.scalar(tbl.count())
+    res2 = await conn1.scalar(select([func.count()]).select_from(tbl))
     assert 0 == res2
 
 
@@ -71,14 +71,14 @@ async def test_root_transaction(connect):
     assert tr.is_active
     await conn1.execute(tbl.delete())
 
-    res1 = await conn2.scalar(tbl.count())
+    res1 = await conn2.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res1
 
     await tr.commit()
 
     assert not tr.is_active
     assert not conn1.in_transaction
-    res2 = await conn2.scalar(tbl.count())
+    res2 = await conn2.scalar(select([func.count()]).select_from(tbl))
     assert 0 == res2
 
 
@@ -90,13 +90,13 @@ async def test_root_transaction_rollback(connect):
     assert tr.is_active
     await conn1.execute(tbl.delete())
 
-    res1 = await conn2.scalar(tbl.count())
+    res1 = await conn2.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res1
 
     await tr.rollback()
 
     assert not tr.is_active
-    res2 = await conn2.scalar(tbl.count())
+    res2 = await conn2.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res2
 
 
@@ -108,13 +108,13 @@ async def test_root_transaction_close(connect):
     assert tr.is_active
     await conn1.execute(tbl.delete())
 
-    res1 = await conn2.scalar(tbl.count())
+    res1 = await conn2.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res1
 
     await tr.close()
 
     assert not tr.is_active
-    res2 = await conn2.scalar(tbl.count())
+    res2 = await conn2.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res2
 
 
@@ -170,12 +170,12 @@ async def test_rollback_on_connection_close(connect):
     tr = await conn1.begin()
     await conn1.execute(tbl.delete())
 
-    res1 = await conn2.scalar(tbl.count())
+    res1 = await conn2.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res1
 
     await conn1.close()
 
-    res2 = await conn2.scalar(tbl.count())
+    res2 = await conn2.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res2
     del tr
 
@@ -191,7 +191,7 @@ async def test_inner_transaction_rollback(connect):
     assert not tr2.is_active
     assert not tr1.is_active
 
-    res = await conn.scalar(tbl.count())
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res
 
 
@@ -207,7 +207,7 @@ async def test_inner_transaction_close(connect):
     assert tr1.is_active
     await tr1.commit()
 
-    res = await conn.scalar(tbl.count())
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 2 == res
 
 
@@ -223,14 +223,14 @@ async def test_nested_transaction_commit(connect):
     assert not tr2.is_active
     assert tr1.is_active
 
-    res = await conn.scalar(tbl.count())
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 2 == res
 
     await tr1.commit()
     assert not tr2.is_active
     assert not tr1.is_active
 
-    res = await conn.scalar(tbl.count())
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 2 == res
 
 
@@ -248,7 +248,7 @@ async def test_nested_transaction_commit_twice(connect):
     assert not tr2.is_active
     assert tr1.is_active
 
-    res = await conn.scalar(tbl.count())
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 2 == res
 
     await tr1.close()
@@ -266,14 +266,14 @@ async def test_nested_transaction_rollback(connect):
     assert not tr2.is_active
     assert tr1.is_active
 
-    res = await conn.scalar(tbl.count())
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res
 
     await tr1.commit()
     assert not tr2.is_active
     assert not tr1.is_active
 
-    res = await conn.scalar(tbl.count())
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res
 
 
@@ -292,7 +292,7 @@ async def test_nested_transaction_rollback_twice(connect):
     assert tr1.is_active
 
     await tr1.commit()
-    res = await conn.scalar(tbl.count())
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res
 
 
@@ -307,7 +307,7 @@ async def test_twophase_transaction_commit(xa_connect):
     await tr.commit()
     assert not tr.is_active
 
-    res = await conn.scalar(tbl.count())
+    res = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 2 == res
 
 
@@ -332,7 +332,7 @@ async def test_transactions_sequence(xa_connect):
     tr1 = await conn.begin()
     assert tr1 is conn._transaction
     await conn.execute(tbl.insert().values(name='a'))
-    res1 = await conn.scalar(tbl.count())
+    res1 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res1
 
     await tr1.commit()
@@ -341,7 +341,7 @@ async def test_transactions_sequence(xa_connect):
     tr2 = await conn.begin()
     assert tr2 is conn._transaction
     await conn.execute(tbl.insert().values(name='b'))
-    res2 = await conn.scalar(tbl.count())
+    res2 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 2 == res2
 
     await tr2.rollback()
@@ -350,7 +350,7 @@ async def test_transactions_sequence(xa_connect):
     tr3 = await conn.begin()
     assert tr3 is conn._transaction
     await conn.execute(tbl.insert().values(name='b'))
-    res3 = await conn.scalar(tbl.count())
+    res3 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 2 == res3
 
     await tr3.commit()
@@ -364,50 +364,50 @@ async def test_transaction_mode(connect):
 
     tr1 = await conn.begin(isolation_level='SERIALIZABLE')
     await conn.execute(tbl.insert().values(name='a'))
-    res1 = await conn.scalar(tbl.count())
+    res1 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 1 == res1
     await tr1.commit()
 
     tr2 = await conn.begin(isolation_level='REPEATABLE READ')
     await conn.execute(tbl.insert().values(name='b'))
-    res2 = await conn.scalar(tbl.count())
+    res2 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 2 == res2
     await tr2.commit()
 
     tr3 = await conn.begin(isolation_level='READ UNCOMMITTED')
     await conn.execute(tbl.insert().values(name='c'))
-    res3 = await conn.scalar(tbl.count())
+    res3 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 3 == res3
     await tr3.commit()
 
     tr4 = await conn.begin(readonly=True)
     assert tr4 is conn._transaction
-    res1 = await conn.scalar(tbl.count())
+    res1 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 3 == res1
     await tr4.commit()
 
     tr5 = await conn.begin(isolation_level='READ UNCOMMITTED',
                            readonly=True)
-    res1 = await conn.scalar(tbl.count())
+    res1 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 3 == res1
     await tr5.commit()
 
     tr6 = await conn.begin(deferrable=True)
     await conn.execute(tbl.insert().values(name='f'))
-    res1 = await conn.scalar(tbl.count())
+    res1 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 4 == res1
     await tr6.commit()
 
     tr7 = await conn.begin(isolation_level='REPEATABLE READ',
                            deferrable=True)
     await conn.execute(tbl.insert().values(name='g'))
-    res1 = await conn.scalar(tbl.count())
+    res1 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 5 == res1
     await tr7.commit()
 
     tr8 = await conn.begin(isolation_level='SERIALIZABLE',
                            readonly=True, deferrable=True)
     assert tr8 is conn._transaction
-    res1 = await conn.scalar(tbl.count())
+    res1 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 5 == res1
     await tr8.commit()


### PR DESCRIPTION
Hi team.
Added `ResourceWarning` warning, if you open a new cursor in one connection, I had to edit the tests. since in many the tests cursor we did not close. Now everything passes.
I will correct the documentation in this PR https://github.com/aio-libs/aiopg/pull/534