### PR TITLE
resolve issues 535 and 364

### DIFF
--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -255,7 +255,6 @@ class Pool(asyncio.AbstractServer):
             if self._closing:
                 conn.close()
             else:
-                conn.free_cursor()
                 self._free.append(conn)
             fut = ensure_future(self._wakeup(), loop=self._loop)
         return fut

--- a/aiopg/sa/connection.py
+++ b/aiopg/sa/connection.py
@@ -1,3 +1,5 @@
+import weakref
+
 from sqlalchemy.sql import ClauseElement
 from sqlalchemy.sql.ddl import DDLElement
 from sqlalchemy.sql.dml import UpdateBase
@@ -16,7 +18,7 @@ class SAConnection:
         self._savepoint_seq = 0
         self._engine = engine
         self._dialect = engine.dialect
-        self._cursor = None
+        self._week_cursor = weakref.WeakSet()
 
     def execute(self, query, *multiparams, **params):
         """Executes a SQL query with optional parameters.
@@ -58,15 +60,10 @@ class SAConnection:
         coro = self._execute(query, *multiparams, **params)
         return _SAConnectionContextManager(coro)
 
-    async def _get_cursor(self):
-        if self._cursor and not self._cursor.closed:
-            return self._cursor
-
-        self._cursor = await self._connection.cursor()
-        return self._cursor
-
     async def _execute(self, query, *multiparams, **params):
-        cursor = await self._get_cursor()
+        cursor = await self._connection.cursor()
+        self._week_cursor.add(cursor)
+
         dp = _distill_params(multiparams, params)
         if len(dp) > 1:
             raise exc.ArgumentError("aiopg doesn't support executemany")
@@ -318,6 +315,11 @@ class SAConnection:
         """Return True if a transaction is in progress."""
         return self._transaction is not None and self._transaction.is_active
 
+    def _close_week_cursor(self):
+        for cursor in self._week_cursor:
+            cursor.close()
+        self._week_cursor.clear()
+
     async def close(self):
         """Close this SAConnection.
 
@@ -340,7 +342,7 @@ class SAConnection:
             self._transaction = None
         # don't close underlying connection, it can be reused by pool
         # conn.close()
-
+        self._close_week_cursor()
         self._engine.release(self)
         self._connection = None
         self._engine = None

--- a/aiopg/sa/connection.py
+++ b/aiopg/sa/connection.py
@@ -18,7 +18,7 @@ class SAConnection:
         self._savepoint_seq = 0
         self._engine = engine
         self._dialect = engine.dialect
-        self._week_cursor = weakref.WeakSet()
+        self._weak_list_cursor = weakref.WeakSet()
 
     def execute(self, query, *multiparams, **params):
         """Executes a SQL query with optional parameters.
@@ -62,7 +62,7 @@ class SAConnection:
 
     async def _execute(self, query, *multiparams, **params):
         cursor = await self._connection.cursor()
-        self._week_cursor.add(cursor)
+        self._weak_list_cursor.add(cursor)
 
         dp = _distill_params(multiparams, params)
         if len(dp) > 1:
@@ -315,10 +315,10 @@ class SAConnection:
         """Return True if a transaction is in progress."""
         return self._transaction is not None and self._transaction.is_active
 
-    def _close_week_cursor(self):
-        for cursor in self._week_cursor:
+    def _close_weak_list_cursor(self):
+        for cursor in self._weak_list_cursor:
             cursor.close()
-        self._week_cursor.clear()
+        self._weak_list_cursor.clear()
 
     async def close(self):
         """Close this SAConnection.
@@ -342,7 +342,7 @@ class SAConnection:
             self._transaction = None
         # don't close underlying connection, it can be reused by pool
         # conn.close()
-        self._close_week_cursor()
+        self._close_weak_list_cursor()
         self._engine.release(self)
         self._connection = None
         self._engine = None

--- a/aiopg/sa/engine.py
+++ b/aiopg/sa/engine.py
@@ -248,7 +248,7 @@ class _ConnectionContextManager:
 
     def __exit__(self, *args):
         try:
-            self._conn._close_week_cursor()
+            self._conn._close_weak_list_cursor()
             self._engine.release(self._conn)
         finally:
             self._conn = None

--- a/aiopg/sa/result.py
+++ b/aiopg/sa/result.py
@@ -233,7 +233,6 @@ class ResultProxy:
 
     def __init__(self, connection, cursor, dialect, result_map=None):
         self._dialect = dialect
-        self._closed = False
         self._result_map = result_map
         self._cursor = cursor
         self._connection = connection
@@ -305,7 +304,10 @@ class ResultProxy:
 
     @property
     def closed(self):
-        return self._closed
+        if self.cursor:
+            return self.cursor.closed
+
+        return True
 
     def close(self):
         """Close this ResultProxy.
@@ -325,8 +327,7 @@ class ResultProxy:
         * cursor.description is None.
         """
 
-        if not self._closed:
-            self._closed = True
+        if not self.closed:
             self._cursor.close()
             # allow consistent errors
             self._cursor = None


### PR DESCRIPTION
Dear all.

I think we hurried using one cursor to connect.
I learned how the connection works. `Cursors are not thread safe: a multithread application can create many cursors from the same connection and should use each cursor from a single thread. See Thread and process safety for details.`  http://initd.org/psycopg/docs/usage.html#thread-safety

This quote may be misleading:
`Connections shouldn’t be shared either by different green threads: see Support for coroutine libraries for further details.` this only applies to `greenlet` more info here (https://github.com/psycopg/psycopg2/blob/8b7506f80d62366ab6bb9e055ff4ea492d16db2c/psycopg/pqpath.c#L830)

**aiopg** use async inteface (https://github.com/psycopg/psycopg2/blob/8b7506f80d62366ab6bb9e055ff4ea492d16db2c/psycopg/pqpath.c#L874) 



issues #364 in that we do not close the cursor, at the time of release for the connection here (https://github.com/aio-libs/aiopg/blob/master/aiopg/sa/engine.py#L244) and here (https://github.com/aio-libs/aiopg/blob/master/aiopg/utils.py#L132)

Solving the problem, was the closure of cursors at the time of release of the connection.
I also track weak references in the `SAConnection` class to release the cursor that closes before it is released connection.

this is necessary in order to clear cursors for users who do not reconfigure the dialect (https://github.com/aio-libs/aiopg/blob/master/aiopg/sa/engine.py#L39)

The default settings are such that `insert` and `update` requests will return to the result. what does not allow to close the cursor.

surprisingly all the tests were successful. and also this example works successfully https://github.com/aio-libs/aiopg/issues/364#issuecomment-373445693
