### PR TITLE
Fix on_connect multiple call on acquire

### DIFF
--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -173,8 +173,6 @@ class Pool(asyncio.AbstractServer):
                     assert not conn.closed, conn
                     assert conn not in self._used, (conn, self._used)
                     self._used.add(conn)
-                    if self._on_connect is not None:
-                        await self._on_connect(conn)
                     return conn
                 else:
                     await self._cond.wait()
@@ -203,6 +201,8 @@ class Pool(asyncio.AbstractServer):
                     enable_uuid=self._enable_uuid,
                     echo=self._echo,
                     **self._conn_kwargs)
+                if self._on_connect is not None:
+                    await self._on_connect(conn)
                 # raise exception if pool is closing
                 self._free.append(conn)
                 self._cond.notify()
@@ -221,6 +221,8 @@ class Pool(asyncio.AbstractServer):
                     enable_uuid=self._enable_uuid,
                     echo=self._echo,
                     **self._conn_kwargs)
+                if self._on_connect is not None:
+                    await self._on_connect(conn)
                 # raise exception if pool is closing
                 self._free.append(conn)
                 self._cond.notify()

--- a/docs/core.rst
+++ b/docs/core.rst
@@ -756,7 +756,7 @@ The basic usage is::
 
    :param bool echo: executed log SQL queryes (disabled by default).
 
-   :param on_connect:  a *callback coroutine* executed at once for every
+   :param on_connect:  a *callback coroutine* executed once for every
      created connection. May be used for setting up connection level
      state like client encoding etc.
 

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -548,7 +548,8 @@ async def test_close_running_cursor(create_pool):
             await cur.execute('SELECT pg_sleep(10)')
 
 
-async def test_pool_on_connect(create_pool):
+@pytest.mark.parametrize('pool_minsize', [0, 1])
+async def test_pool_on_connect(create_pool, pool_minsize):
     cb_called_times = 0
 
     async def cb(connection):
@@ -560,6 +561,7 @@ async def test_pool_on_connect(create_pool):
             cb_called_times += 1
 
     pool = await create_pool(
+        minsize=pool_minsize,
         maxsize=1,
         on_connect=cb
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Fixes #551 

<!-- Please give a short brief about these changes. -->

The Pool `on_connect` handler is now called exactly once per connection, rather than on every call to `acquire`


Also, some things on your PR template checklist can't be done, as you don't have a CONTRIBUTORS.txt or a CHANGES folder?

<!-- Outline any notable behaviour for the end users. -->

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- ~~If you provide code modification, please add yourself to `CONTRIBUTORS.txt`~~
- ~~Add a new news fragment into the `CHANGES` folder~~
