### PR TITLE
Fixes Engine.release method to release connection in any way

### DIFF
--- a/aiopg/sa/engine.py
+++ b/aiopg/sa/engine.py
@@ -4,7 +4,6 @@ import json
 import aiopg
 
 from .connection import SAConnection
-from .exc import InvalidRequestError
 from ..connection import TIMEOUT
 from ..utils import _PoolContextManager, _PoolAcquireContextManager
 
@@ -171,9 +170,6 @@ class Engine:
 
     def release(self, conn):
         """Revert back connection to pool."""
-        if conn.in_transaction:
-            raise InvalidRequestError("Cannot release a connection with "
-                                      "not finished transaction")
         raw = conn.connection
         fut = self._pool.release(raw)
         return fut


### PR DESCRIPTION
Fixes #332 error.

The problem is that `Engine.release` method raises `InvalidRequestError` exception before releasing connection. This may happen not only when user did something wrong, but also when connection becomes broken. Pool becomes exhausted and application stops responding.

I think that it doesn't matter who is guilty, connection should be released in any way, and `Pool.release` also checks connection's state, and if it is not in IDLE state, pool closes connection.

I've added `test_release_broken_connection` to reproduce this error. Currently `Pool.release` emits `ResourceWarning`, I think that it is enough.