### PR TITLE
Fix "Unable to detect disconnect when using NOTIFY/LISTEN", Closes #249

### DIFF
--- a/docs/core.rst
+++ b/docs/core.rst
@@ -289,7 +289,7 @@ Example::
 
    .. attribute:: notifies
 
-      An :class:`asyncio.Queue` instance for received notifications.
+      An instance of an :class:`asyncio.Queue` subclass for received notifications.
 
       .. seealso:: :ref:`aiopg-core-notifications`
 
@@ -982,6 +982,12 @@ from Python code simply executing a NOTIFY_ command in an
 Receiving part should establish listening on notification channel by
 `LISTEN`_ call and wait notification events from
 :attr:`Connection.notifies` queue.
+
+.. note::
+
+  calling `await connection.notifies.get()` may raise a psycopg2 exception
+  if the underlying connection gets disconnected while you're waiting for
+  notifications.
 
 There is usage example:
 

--- a/examples/notify.py
+++ b/examples/notify.py
@@ -1,5 +1,7 @@
 import asyncio
 
+import psycopg2
+
 import aiopg
 
 dsn = "dbname=aiopg user=aiopg password=passwd host=127.0.0.1"
@@ -19,8 +21,12 @@ async def listen(conn):
     async with conn.cursor() as cur:
         await cur.execute("LISTEN channel")
         while True:
-            msg = await conn.notifies.get()
-            if msg.payload == "finish":
+            try:
+                msg = await conn.notifies.get()
+            except psycopg2.Error as ex:
+                print("ERROR: ", ex)
+                return
+            if msg.payload == 'finish':
                 return
             else:
                 print("Receive <-", msg.payload)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,70 @@
+import asyncio
+
+import pytest
+
+from aiopg.utils import ClosableQueue
+
+
+async def test_closable_queue_noclose():
+    the_queue = asyncio.Queue()
+    queue = ClosableQueue(the_queue)
+    assert queue.empty()
+    assert queue.qsize() == 0
+
+    await the_queue.put(1)
+    assert not queue.empty()
+    assert queue.qsize() == 1
+    v = await queue.get()
+    assert v == 1
+
+    await the_queue.put(2)
+    v = queue.get_nowait()
+    assert v == 2
+
+
+async def test_closable_queue_close(loop):
+    the_queue = asyncio.Queue()
+    queue = ClosableQueue(the_queue)
+    v1 = None
+
+    async def read():
+        nonlocal v1
+        v1 = await queue.get()
+        await queue.get()
+
+    reader = loop.create_task(read())
+    await the_queue.put(1)
+    await asyncio.sleep(0.1)
+    assert v1 == 1
+
+    queue.close(RuntimeError("connection closed"))
+    with pytest.raises(RuntimeError) as excinfo:
+        await reader
+    assert excinfo.value.args == ("connection closed",)
+
+
+async def test_closable_queue_close_get_nowait(loop):
+    the_queue = asyncio.Queue()
+    queue = ClosableQueue(the_queue)
+
+    await the_queue.put(1)
+    queue.close(RuntimeError("connection closed"))
+
+    # even when the queue is closed, while there are items in the queu, we
+    # allow reading them.
+    assert queue.get_nowait() == 1
+
+    # when there are no more items in the queue, if there is a close exception
+    # then it will get raises here
+    with pytest.raises(RuntimeError) as excinfo:
+        queue.get_nowait()
+    assert excinfo.value.args == ("connection closed",)
+
+
+async def test_closable_queue_get_nowait_noclose(loop):
+    the_queue = asyncio.Queue()
+    queue = ClosableQueue(the_queue)
+    await the_queue.put(1)
+    assert queue.get_nowait() == 1
+    with pytest.raises(asyncio.QueueEmpty):
+        queue.get_nowait()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

When connection to DB is closed, any tasks pending on `await connection.notifies.get()` receives an exception, instead of hanging forever.

## Are there changes in behavior for the user?

Now `connection.notifies.get()` can raise a psycopg2 exception, whereas before this would hang forever.

## Related issue number

#249

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is `<Name> <Surname>`.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
