### PR TITLE
Fixing connection with multiple hosts and unavailable replicas

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -45,8 +45,8 @@ class TestMultipleHostsWithUnavailable:
         extra_host = "127.0.0.1"
         extra_port = unused_port()
 
-        pg_params['host'] = f'{extra_host},{host}'
-        pg_params['port'] = f'{extra_port},{port}'
+        pg_params['host'] = '{extra_host},{host}'.format(extra_host=extra_host, host=host)
+        pg_params['port'] = '{extra_port},{port}'.format(extra_port=extra_port, port=port)
         return pg_params
 
     async def test_connect(self, connect):
@@ -77,8 +77,8 @@ class TestMultipleHostsWithStuckConnection:
         extra_host = "127.0.0.1"
         extra_port = stuck_server_port
 
-        pg_params['host'] = f'{extra_host},{host}'
-        pg_params['port'] = f'{extra_port},{port}'
+        pg_params['host'] = '{extra_host},{host}'.format(extra_host=extra_host, host=host)
+        pg_params['port'] = '{extra_port},{port}'.format(extra_port=extra_port, port=port)
         pg_params['connect_timeout'] = 1
         pg_params['timeout'] = 3
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -45,8 +45,10 @@ class TestMultipleHostsWithUnavailable:
         extra_host = "127.0.0.1"
         extra_port = unused_port()
 
-        pg_params['host'] = '{extra_host},{host}'.format(extra_host=extra_host, host=host)
-        pg_params['port'] = '{extra_port},{port}'.format(extra_port=extra_port, port=port)
+        pg_params['host'] = '{extra_host},{host}'.format(
+            extra_host=extra_host, host=host)
+        pg_params['port'] = '{extra_port},{port}'.format(
+            extra_port=extra_port, port=port)
         return pg_params
 
     async def test_connect(self, connect):
@@ -77,8 +79,10 @@ class TestMultipleHostsWithStuckConnection:
         extra_host = "127.0.0.1"
         extra_port = stuck_server_port
 
-        pg_params['host'] = '{extra_host},{host}'.format(extra_host=extra_host, host=host)
-        pg_params['port'] = '{extra_port},{port}'.format(extra_port=extra_port, port=port)
+        pg_params['host'] = '{extra_host},{host}'.format(
+            extra_host=extra_host, host=host)
+        pg_params['port'] = '{extra_port},{port}'.format(
+            extra_port=extra_port, port=port)
         pg_params['connect_timeout'] = 1
         pg_params['timeout'] = 3
 


### PR DESCRIPTION
## What do these changes do?

Since PostgreSQL 10 it's possible to describe multiple hosts in connection string, it is useful when you have HA cluster of PostgreSQL with several replicas and you don't want to have some kind of balancer over your replicas.   

And know it works in `aiopg` if you're using libpq =< 10. 

But if there is a dead or unavailable replica in your connection string before your target host, exception is raised after timeout: ```psycopg2.OperationalError: asynchronous connection attempt underway```.
It is also happens when you have host with multiple ip addresses in DNS, and first one is not responding. 

You can simply reproduce this behavior  by setting up 1 PostgreSQL server on 127.0.0.1:5432 and try to connect with connection string:
`dbname=<db> user=<user> password=<password> host=8.8.8.8,127.0.0.1 port=5433,5432 target_session_attrs=read-write connect_timeout=1`

In sync psycopg2 connection it  works properly, but this code:

```
import asyncio
import aiopg

dsn = 'dbname=<db> user=<user> password=<password> host=8.8.8.8,127.0.0.1 port=5433,5432 target_session_attrs=read-write connect_timeout=1'


async def go():
    async with aiopg.create_pool(dsn, timeout=3) as pool:
        async with pool.acquire() as conn:
            async with conn.cursor() as cur:
                await cur.execute("SELECT 1")
                ret = []
                async for row in cur:
                    ret.append(row)
                assert ret == [(1,)]

loop = asyncio.get_event_loop()
loop.run_until_complete(go())
```

raises ```psycopg2.OperationalError: asynchronous connection attempt underway```.

This happens because libpq creates new connection, and closes failed, but we are waiting a failed one in `_poll` method and fails after timeout. 

## Are there changes in behavior for the user?

Now `aiopg` uses  `connect_timeout` param from `dsn`. 
It is used to timeout connection to the single host, in order to prevent getting stuck on connection to host which is not responding at all, even on first `SYN` packet. 

So now, if you have 3 hosts in your connection string, you should provide `connect_timeout` = `timeout / 3`  just as guarantee that `aiopg` will try all 3 host during the timeout. 

```
# we will wait single host for 1 second and whole connect operation will take 3 seconds at worst case
pool = aiopg.create_pool('host=localhost ... connect_timeout=1', timeout=3)
```
You can also use `connect_timeout` in `kwargs`:

```
pool = aiopg.create_pool('host=localhost ...', timeout=3, connect_timeout=1)
```

## Related issue number

#275 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
