### PR TITLE
Fix changelog markup

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 1.0.0 (2019-09-20)
+^^^^^^^^^^^^^^^^^^
+
 * Removal of an asynchronous call in favor of issues # 550
+
 * Big editing of documentation and minor bugs #534
+
 
 0.16.0 (2019-01-25)
 ^^^^^^^^^^^^^^^^^^^
@@ -21,10 +25,12 @@
 
 * Support Python 3.7 `#437 <https://github.com/aio-libs/aiopg/issues/437>`_
 
+
 0.14.0 (2018-05-10)
 ^^^^^^^^^^^^^^^^^^^
 
 * Add ``get_dialect`` func to have ability to pass ``json_serializer`` `#451 <https://github.com/aio-libs/aiopg/issues/451>`_
+
 
 0.13.2 (2018-01-03)
 ^^^^^^^^^^^^^^^^^^^
@@ -61,12 +67,14 @@
 
 * Fixed connection to work under both windows and posix based systems `#142 <https://github.com/aio-libs/aiopg/issues/142>`_
 
+
 0.11.0 (2016-09-12)
 ^^^^^^^^^^^^^^^^^^^
 
 * Immediately remove callbacks from a closed file descriptor `#139 <https://github.com/aio-libs/aiopg/issues/139>`_
 
 * Drop Python 3.3 support
+
 
 0.10.0 (2016-07-16)
 ^^^^^^^^^^^^^^^^^^^
@@ -83,6 +91,7 @@
 
 * Use loop.create_future() if available
 
+
 0.9.2 (2016-01-31)
 ^^^^^^^^^^^^^^^^^^
 
@@ -91,10 +100,12 @@
 
 * Add support for uuid type `#103 <https://github.com/aio-libs/aiopg/issues/103>`_
 
+
 0.9.1 (2016-01-17)
 ^^^^^^^^^^^^^^^^^^
 
 * Documentation update `#101 <https://github.com/aio-libs/aiopg/issues/101>`_
+
 
 0.9.0 (2016-01-14)
 ^^^^^^^^^^^^^^^^^^
@@ -104,6 +115,7 @@
 * Support async iterator in ResultProxy `#92 <https://github.com/aio-libs/aiopg/issues/92>`_
 
 * Add async with for engine `#90 <https://github.com/aio-libs/aiopg/issues/90>`_
+
 
 0.8.0 (2015-12-31)
 ^^^^^^^^^^^^^^^^^^
@@ -116,6 +128,7 @@
 
 * Add async with support for Pool, Connection, Cursor `#88 <https://github.com/aio-libs/aiopg/issues/88>`_
 
+
 0.7.0 (2015-04-22)
 ^^^^^^^^^^^^^^^^^^
 
@@ -127,11 +140,13 @@
 
 * Release sa connection to pool on `connection.close()`.
 
+
 0.6.0 (2015-02-03)
 ^^^^^^^^^^^^^^^^^^
 
 * Accept dict, list, tuple, named and positional parameters in
   `SAConnection.execute()`
+
 
 0.5.2 (2014-12-08)
 ^^^^^^^^^^^^^^^^^^
@@ -139,10 +154,12 @@
 * Minor release, fixes a bug that leaves connection in broken state
   after `cursor.execute()` failure.
 
+
 0.5.1 (2014-10-31)
 ^^^^^^^^^^^^^^^^^^
 
 * Fix a bug for processing transactions in line.
+
 
 0.5.0 (2014-10-31)
 ^^^^^^^^^^^^^^^^^^
@@ -159,12 +176,14 @@
 
 * Connection.close() is not a coroutine (but we keep backward compatibility).
 
+
 0.4.1 (2014-10-02)
 ^^^^^^^^^^^^^^^^^^
 
 * make cursor iterable
 
 * update docs
+
 
 0.4.0 (2014-10-02)
 ^^^^^^^^^^^^^^^^^^
@@ -181,16 +200,19 @@
 
 * Support HSTORE in aiopg.sa
 
+
 0.3.2 (2014-07-07)
 ^^^^^^^^^^^^^^^^^^
 
 * change signature to cursor.execute(operation, parameters=None) to
   follow psycopg2 convention.
 
+
 0.3.1 (2014-07-04)
 ^^^^^^^^^^^^^^^^^^
 
 * Forward arguments to cursor constructor for pooled connections.
+
 
 0.3.0 (2014-06-22)
 ^^^^^^^^^^^^^^^^^^
@@ -199,10 +221,12 @@
 
 * Fix bug with race conditions on acquiring/releasing connections from pool.
 
+
 0.2.3 (2014-06-12)
 ^^^^^^^^^^^^^^^^^^
 
 * Fix bug in connection pool.
+
 
 0.2.2 (2014-06-07)
 ^^^^^^^^^^^^^^^^^^
@@ -210,15 +234,18 @@
 * Fix bug with passing parameters into SAConnection.execute when
   executing raw SQL expression.
 
+
 0.2.1 (2014-05-08)
 ^^^^^^^^^^^^^^^^^^
 
 * Close connection with invalid transaction status on returning to pool.
 
+
 0.2.0 (2014-05-04)
 ^^^^^^^^^^^^^^^^^^
 
 * Implemented optional support for sqlalchemy functional sql layer.
+
 
 0.1.0 (2014-04-06)
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
The presentation of the changelog at https://aiopg.readthedocs.io/en/stable/changes.html is broken due to missing heading markdown for version 1.0.0.

This change fixes the presentation by adding the missing markup.

In addition, missing blank lines are inserted for a consistent plain text view.