### PR TITLE
Fix python 3.8 warnings #622

### DIFF
--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -54,7 +54,7 @@ class Pool(asyncio.AbstractServer):
         self._conn_kwargs = kwargs
         self._acquiring = 0
         self._free = collections.deque(maxlen=maxsize or None)
-        self._cond = asyncio.Condition(loop=self._loop)
+        self._cond = asyncio.Condition()
         self._used = set()
         self._terminated = set()
         self._closing = False


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix deprecation warnings where a loop argument is passed to asyncio APIs

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

https://github.com/aio-libs/aiopg/issues/622
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
