### PR TITLE
Rework aiopg.sa.result module with Cython.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     env:
 
 install:
-- pip install -U setuptools
+- pip install -U setuptools cython
 - python setup.py install
 - pip install -Ur requirements.txt
 - pip install codecov

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 import os
 import re
 
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Extension
+from Cython.Build import cythonize
+
+CFLAGS = ['-O3']
 
 install_requires = ['psycopg2-binary>=2.7.0']
 extras_require = {'sa': ['sqlalchemy[postgresql_psycopg2binary]>=1.1']}
@@ -50,6 +53,14 @@ classifiers = [
     'Framework :: AsyncIO',
 ]
 
+EXTENSIONS = [
+    Extension(
+        "aiopg.sa.result",
+        sources=["aiopg/sa/result.pyx"],
+        extra_compile_args=CFLAGS
+    )
+]
+
 setup(
     name='aiopg',
     version=read_version(),
@@ -76,5 +87,6 @@ setup(
     packages=find_packages(),
     install_requires=install_requires,
     extras_require=extras_require,
-    include_package_data=True
+    include_package_data=True,
+    ext_modules=cythonize(EXTENSIONS)
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -130,11 +130,15 @@ def pg_server(unused_port, docker, session_id, pg_tag, request):
     if not request.config.option.no_pull:
         docker.pull('postgres:{}'.format(pg_tag))
 
+    db_password = 'mysecretpassword'
     container_args = dict(
         image='postgres:{}'.format(pg_tag),
         name='aiopg-test-server-{}-{}'.format(pg_tag, session_id),
         ports=[5432],
         detach=True,
+        environment={
+            'POSTGRES_PASSWORD': db_password
+        }
     )
 
     # bound IPs do not work on OSX
@@ -149,7 +153,7 @@ def pg_server(unused_port, docker, session_id, pg_tag, request):
         docker.start(container=container['Id'])
         server_params = dict(database='postgres',
                              user='postgres',
-                             password='mysecretpassword',
+                             password=db_password,
                              host=host,
                              port=host_port)
         delay = 0.001
@@ -173,8 +177,7 @@ def pg_server(unused_port, docker, session_id, pg_tag, request):
 
         yield container
     finally:
-        docker.kill(container=container['Id'])
-        docker.remove_container(container['Id'])
+        docker.remove_container(container['Id'], force=True)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

I've noticed that classes `ResultProxy` and `RowProxy` are bottlenecks in one of my projects and that other libraries like SQLAlchemy or Asyncpg implement similar classes in C for speed [\[1\]][1], [\[2\]][2].

I decided to start experimenting with doing the same thing in Aiopg - I've done some simple optimizations using Cython and already got some positive results using this benchmark setup: https://gist.github.com/AndreiPashkin/dd6aa232f91deaa987b5ee0285ad9b7d

Results before:
```
simple [1.3329865639971104, 1.3546994640055345, 1.349644674002775]
json [1.6616086649883073, 2.042356903999462, 2.0650724380102474]
```

Results after:
```
simple [0.5680085269996198, 0.5687800829909975, 0.5716462380078156]
json [0.8984643409930868, 0.8978340939938789, 0.8937820449937135]
```

[1]: https://github.com/MagicStack/asyncpg/blob/1d4325c7c4a15a8e2d3c5c1abfd8189cc1459ee2/asyncpg/protocol/record/recordobj.c
[2]: https://github.com/sqlalchemy/sqlalchemy/blob/fcc8307c3d407058337da9318da6e83d1a0ce960/lib/sqlalchemy/cextension/resultproxy.c

What do maintainers think about this? I it worth to continue? Maybe it's even worth to simply re-use fast `ResultProxy` implementation from SQLAlchemy?

## Are there changes in behavior for the user?

Theoretically everything should be backwards-compatible

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
