### PR TITLE
Pass POSTGRES_HOST_AUTH_METHOD=trust

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,7 +141,9 @@ def pg_server(unused_port, docker, session_id, pg_tag, request):
     host = "127.0.0.1"
     host_port = unused_port()
     container_args['host_config'] = docker.create_host_config(
-        port_bindings={5432: (host, host_port)})
+        port_bindings={5432: (host, host_port)}
+    )
+    container_args['environment'] = {'POSTGRES_HOST_AUTH_METHOD': 'trust'}
 
     container = docker.create_container(**container_args)
 


### PR DESCRIPTION
It looks like fresh PG images are not able to start without `POSTGRES_HOST_AUTH_METHOD=trust` in env 