### PR TITLE
Bump psycorg and sqlalchemy, add python 3.8, 3.9 to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
         python:
           - 3.6
           - 3.7
+          - 3.8
+          - 3.9
       fail-fast: false
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pytest-cov==2.8.1
 pytest-sugar==0.9.2
 pytest-timeout==1.3.4
 sphinxcontrib-asyncio==0.2.0
-psycopg2-binary==2.8.4
-sqlalchemy[postgresql_psycopg2binary]==1.3.14
+psycopg2-binary==2.8.6
+sqlalchemy[postgresql_psycopg2binary]==1.3.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ pytest-cov==2.8.1
 pytest-sugar==0.9.2
 pytest-timeout==1.3.4
 sphinxcontrib-asyncio==0.2.0
-psycopg2-binary==2.7.7
-sqlalchemy[postgresql_psycopg2binary]==1.3.13
+psycopg2-binary==2.8.4
+sqlalchemy[postgresql_psycopg2binary]==1.3.14

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import re
 from setuptools import setup, find_packages
 
 install_requires = ['psycopg2-binary>=2.8.4']
-extras_require = {'sa': ['sqlalchemy[postgresql_psycopg2binary]>=1.3.14']}
+extras_require = {'sa': ['sqlalchemy[postgresql_psycopg2binary]>=1.1']}
 
 
 def read(f):

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import re
 
 from setuptools import setup, find_packages
 
-install_requires = ['psycopg2-binary>=2.7.0']
-extras_require = {'sa': ['sqlalchemy[postgresql_psycopg2binary]>=1.1']}
+install_requires = ['psycopg2-binary>=2.8.4']
+extras_require = {'sa': ['sqlalchemy[postgresql_psycopg2binary]>=1.3.14']}
 
 
 def read(f):
@@ -39,6 +39,8 @@ classifiers = [
     'Programming Language :: Python :: 3 :: Only',
     'Programming Language :: Python :: 3.6',
     'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'Operating System :: POSIX',
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: Microsoft :: Windows',

--- a/tests/test_async_await.py
+++ b/tests/test_async_await.py
@@ -1,6 +1,5 @@
 import asyncio
 
-import psycopg2
 import pytest
 
 import aiopg
@@ -56,7 +55,7 @@ async def test_pool_context_manager_timeout(pg_params, loop):
     async with aiopg.create_pool(**pg_params, minsize=1,
                                  maxsize=1) as pool:
         cursor_ctx = await pool.cursor()
-        with pytest.raises(psycopg2.ProgrammingError):
+        with pytest.warns(ResourceWarning):
             with cursor_ctx as cursor:
                 hung_task = cursor.execute('SELECT pg_sleep(10000);')
                 # start task


### PR DESCRIPTION
Min supported version of psycorg is 2.8.4 because of python 3.8