### PR TITLE
Fix Engine.release method to release connection in any way

### DIFF
--- a/aiopg/sa/engine.py
+++ b/aiopg/sa/engine.py
@@ -5,7 +5,6 @@ import aiopg
 from ..connection import TIMEOUT
 from ..utils import _PoolAcquireContextManager, _PoolContextManager
 from .connection import SAConnection
-from .exc import InvalidRequestError
 
 try:
     from sqlalchemy.dialects.postgresql.psycopg2 import (
@@ -169,10 +168,6 @@ class Engine:
         return conn
 
     def release(self, conn):
-        """Revert back connection to pool."""
-        if conn.in_transaction:
-            raise InvalidRequestError("Cannot release a connection with "
-                                      "not finished transaction")
         raw = conn.connection
         fut = self._pool.release(raw)
         return fut

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -434,7 +434,8 @@ class TcpProxy:
         while self.connections:
             writer = self.connections.pop()
             writer.close()
-            await writer.wait_closed()
+            if hasattr(writer, "wait_closed"):
+                await writer.wait_closed()
 
     @staticmethod
     async def _pipe(

--- a/tests/test_async_await.py
+++ b/tests/test_async_await.py
@@ -55,7 +55,7 @@ async def test_pool_context_manager_timeout(pg_params, loop):
     async with aiopg.create_pool(**pg_params, minsize=1,
                                  maxsize=1) as pool:
         cursor_ctx = await pool.cursor()
-        with pytest.warns(ResourceWarning):
+        with pytest.warns(ResourceWarning, match='Invalid transaction status'):
             with cursor_ctx as cursor:
                 hung_task = cursor.execute('SELECT pg_sleep(10000);')
                 # start task

--- a/tests/test_sa_engine.py
+++ b/tests/test_sa_engine.py
@@ -189,4 +189,5 @@ async def test_release_after_connection_disconnected_before_begin(
                 await tcp_proxy.disconnect()
                 async with conn.begin():
                     pytest.fail("Should not be here")
+
     assert engine.size == 0

--- a/tests/test_sa_engine.py
+++ b/tests/test_sa_engine.py
@@ -1,5 +1,6 @@
 import asyncio
 
+import psycopg2
 import pytest
 from psycopg2.extensions import parse_dsn
 from sqlalchemy import Column, Integer, MetaData, String, Table
@@ -80,10 +81,10 @@ def test_not_context_manager(engine):
 async def test_release_transacted(engine):
     conn = await engine.acquire()
     tr = await conn.begin()
-    with pytest.raises(sa.InvalidRequestError):
-        engine.release(conn)
+    with pytest.warns(ResourceWarning, match='Invalid transaction status'):
+        await engine.release(conn)
     del tr
-    await conn.close()
+    assert conn.closed
 
 
 def test_timeout(engine):
@@ -147,3 +148,24 @@ async def test_terminate_with_acquired_connections(make_engine):
     await engine.wait_closed()
 
     assert conn.closed
+
+
+async def test_release_disconnected_connection(
+    tcp_proxy, unused_port, pg_params, make_engine
+):
+    server_port = pg_params["port"]
+    proxy_port = unused_port()
+
+    tcp_proxy = await tcp_proxy(proxy_port, server_port)
+    engine = await make_engine(port=proxy_port)
+
+    with pytest.raises(
+        psycopg2.InterfaceError, match='connection already closed'
+    ):
+        with pytest.warns(ResourceWarning, match='Invalid transaction status'):
+            async with engine.acquire() as conn, conn.begin():
+                await conn.execute('SELECT 1;')
+                await tcp_proxy.disconnect()
+                await conn.execute('SELECT 1;')
+
+    assert engine.size == 0


### PR DESCRIPTION
The goal of the PR is to actualise the fix made in #558 by @vmagamedov, but with slightly reworked tests.

Fixes #332, #665, #666 as well.

It looks like both exceptions(`psycopg2.InterfaceError` and `psycopg2.OperationalError`) could be raised, see https://github.com/aio-libs/aiopg/pull/756/checks?check_run_id=1503163697, initially only the first one was expected in the tests.

Tests are written using intermediate tcp proxy to allow disrupt a connection and cover two cases:
1. When a connection has disrupted before a request(`SELECT 1;` for instance) is executed, so rollback could not be executed. 
2. When a connection has disrupted before begin is executed.