### PR TITLE
Release 1.1.0b0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,5 @@
 1.1.0b0 (2020-12-07)
-^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^
 
 * Fix on_connect multiple call on acquire `#552 https://github.com/aio-libs/aiopg/pull/552`_
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,15 @@
+1.1.0 (2020-12-11)
+^^^^^^^^^^^^^^^^^^
+
+* Fix on_connect multiple call on acquire `#552 https://github.com/aio-libs/aiopg/pull/552`_
+
+* Fix python 3.8 warnings `#622 https://github.com/aio-libs/aiopg/pull/642`_
+
+* Bump minimum psycopg version to 2.8.4 `#754 https://github.com/aio-libs/aiopg/pull/754`_
+
+* Fix Engine.release method to release connection in any way `#756 https://github.com/aio-libs/aiopg/pull/756`_
+
+
 1.0.0 (2019-09-20)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-1.1.0 (2020-12-11)
+1.1.0b (2020-12-07)
 ^^^^^^^^^^^^^^^^^^
 
 * Fix on_connect multiple call on acquire `#552 https://github.com/aio-libs/aiopg/pull/552`_

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,4 +1,4 @@
-1.1.0b (2020-12-07)
+1.1.0b0 (2020-12-07)
 ^^^^^^^^^^^^^^^^^^
 
 * Fix on_connect multiple call on acquire `#552 https://github.com/aio-libs/aiopg/pull/552`_

--- a/MAINTAINERS.txt
+++ b/MAINTAINERS.txt
@@ -1,3 +1,4 @@
 * Andrew Svetlov <andrew.svetlov@gmail.com>
 * Alexey Firsov <virmir49@gmail.com>
 * Alexey Popravka <alexey.popravka@horsedevel.com>
+* Yury Pliner <yury.pliner@gmail.com>

--- a/aiopg/__init__.py
+++ b/aiopg/__init__.py
@@ -21,7 +21,7 @@ __all__ = ('connect', 'create_pool', 'get_running_loop',
            'Connection', 'Cursor', 'Pool', 'version', 'version_info',
            'DEFAULT_TIMEOUT', 'IsolationLevel', 'Transaction')
 
-__version__ = '1.1.0a0'
+__version__ = '1.1.0'
 
 version = __version__ + ' , Python ' + sys.version
 

--- a/aiopg/__init__.py
+++ b/aiopg/__init__.py
@@ -21,7 +21,7 @@ __all__ = ('connect', 'create_pool', 'get_running_loop',
            'Connection', 'Cursor', 'Pool', 'version', 'version_info',
            'DEFAULT_TIMEOUT', 'IsolationLevel', 'Transaction')
 
-__version__ = '1.1.0'
+__version__ = '1.1.0b'
 
 version = __version__ + ' , Python ' + sys.version
 

--- a/aiopg/__init__.py
+++ b/aiopg/__init__.py
@@ -21,7 +21,7 @@ __all__ = ('connect', 'create_pool', 'get_running_loop',
            'Connection', 'Cursor', 'Pool', 'version', 'version_info',
            'DEFAULT_TIMEOUT', 'IsolationLevel', 'Transaction')
 
-__version__ = '1.1.0b'
+__version__ = '1.1.0b0'
 
 version = __version__ + ' , Python ' + sys.version
 


### PR DESCRIPTION
1. `Fix on_connect multiple call on acquire` #552
1. `Fix python 3.8` warnings #622
1. `Bump minimum psycopg version to 2.8.4` #754 
1. `Fix Engine.release method to release connection in any way` #756