### PR TITLE
Use loop.create_future directly

### DIFF
--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -10,7 +10,6 @@ from .utils import (
     _PoolConnectionContextManager,
     _PoolContextManager,
     _PoolCursorContextManager,
-    create_future,
     ensure_future,
     get_running_loop,
 )
@@ -230,7 +229,7 @@ class Pool(asyncio.AbstractServer):
     def release(self, conn):
         """Release free connection back to the connection pool.
         """
-        fut = create_future(self._loop)
+        fut = self._loop.create_future()
         fut.set_result(None)
         if conn in self._terminated:
             assert conn.closed, conn

--- a/aiopg/utils.py
+++ b/aiopg/utils.py
@@ -43,13 +43,6 @@ def get_running_loop(is_warn: bool = False) -> asyncio.AbstractEventLoop:
     return loop
 
 
-def create_future(loop):
-    try:
-        return loop.create_future()
-    except AttributeError:
-        return asyncio.Future(loop=loop)
-
-
 class _ContextManager(Coroutine):
     __slots__ = ('_coro', '_obj')
 


### PR DESCRIPTION
It looks like we are able to use loop.create_future directly, because now we supports python 3.6 and above.

https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.create_future

![image](https://user-images.githubusercontent.com/664889/101982471-eeda2700-3c95-11eb-9c61-f0c6a41348ca.png)


