### PR TITLE
Implement timeout on acquiring connection from pool

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+1.2.0b0 (2020-12-15)
+^^^^^^^^^^^^^^^^^^^^
+
+* Implement timeout on acquiring connection from pool `#766 <https://github.com/aio-libs/aiopg/pull/766>`_
+
+
 1.1.0 (2020-12-10)
 ^^^^^^^^^^^^^^^^^^
 

--- a/aiopg/__init__.py
+++ b/aiopg/__init__.py
@@ -21,7 +21,7 @@ __all__ = ('connect', 'create_pool', 'get_running_loop',
            'Connection', 'Cursor', 'Pool', 'version', 'version_info',
            'DEFAULT_TIMEOUT', 'IsolationLevel', 'Transaction')
 
-__version__ = '1.1.0'
+__version__ = '1.2.0b0'
 
 version = __version__ + ' , Python ' + sys.version
 

--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -2,6 +2,7 @@ import asyncio
 import collections
 import warnings
 
+import async_timeout
 from psycopg2.extensions import TRANSACTION_STATUS_IDLE
 
 from .connection import TIMEOUT, connect
@@ -158,7 +159,7 @@ class Pool(asyncio.AbstractServer):
     async def _acquire(self):
         if self._closing:
             raise RuntimeError("Cannot acquire connection after closing pool")
-        async with self._cond:
+        async with async_timeout.timeout(self._timeout), self._cond:
             while True:
                 await self._fill_free_pool(True)
                 if self._free:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pytest-timeout==1.4.2
 sphinxcontrib-asyncio==0.3.0
 psycopg2-binary==2.8.6
 sqlalchemy[postgresql_psycopg2binary]==1.3.20
+async-timeout==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import re
 
 from setuptools import setup, find_packages
 
-install_requires = ['psycopg2-binary>=2.8.4']
+install_requires = ['psycopg2-binary>=2.8.4', 'async_timeout>=3.0,<4.0']
 extras_require = {'sa': ['sqlalchemy[postgresql_psycopg2binary]>=1.1']}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -424,8 +424,8 @@ class TcpProxy:
         self.connections = set()
 
     async def start(self):
-        return await asyncio.start_server(
-            self.handle_client,
+        await asyncio.start_server(
+            self._handle_client,
             host=self.src_host,
             port=self.src_port,
         )
@@ -445,10 +445,11 @@ class TcpProxy:
             while not reader.at_eof():
                 bytes_read = await reader.read(TcpProxy.MAX_BYTES)
                 writer.write(bytes_read)
+                await writer.drain()
         finally:
             writer.close()
 
-    async def handle_client(
+    async def _handle_client(
         self,
         client_reader: asyncio.StreamReader,
         client_writer: asyncio.StreamWriter,

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -571,3 +571,11 @@ async def test_pool_on_connect(create_pool, pool_minsize):
         await cur.execute('SELECT 1')
 
     assert cb_called_times == 1
+
+
+async def test_acquire_timeout_no_connections_available(create_pool):
+    pool = await create_pool(minsize=1, maxsize=1, timeout=5)
+    async with pool.acquire():
+        with pytest.raises(asyncio.TimeoutError):
+            async with pool.acquire():
+                pytest.fail("Should not be here")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

PR adds timeout for the acquiring a connection from the pool.

## Are there changes in behavior for the user?

`Pool.acquire` will raise `TimeoutError` if no connection is returned from the pool in specified timeout. 

## Related issue number

Fixes #130, #218

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes