### PR TITLE
Fix IsolationLevel.read_comitted and introduce IsolationLevel.default

### DIFF
--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -199,7 +199,7 @@ class Connection:
         return self._conn.isexecuting()
 
     def cursor(self, name=None, cursor_factory=None,
-               scrollable=None, withhold=False, timeout=None):
+               scrollable=None, withhold=False, timeout=None, isolation_level=None):
         """A coroutine that returns a new cursor object using the connection.
 
         *cursor_factory* argument can be used to create non-standard
@@ -215,11 +215,12 @@ class Connection:
         self._last_usage = self._loop.time()
         coro = self._cursor(name=name, cursor_factory=cursor_factory,
                             scrollable=scrollable, withhold=withhold,
-                            timeout=timeout)
+                            timeout=timeout, isolation_level=isolation_level)
         return _ContextManager(coro)
 
     async def _cursor(self, name=None, cursor_factory=None,
-                      scrollable=None, withhold=False, timeout=None):
+                      scrollable=None, withhold=False, timeout=None,
+                      isolation_level=None):
 
         if not self.closed_cursor:
             warnings.warn(('You can only have one cursor per connection. '
@@ -235,7 +236,7 @@ class Connection:
                                        cursor_factory=cursor_factory,
                                        scrollable=scrollable,
                                        withhold=withhold)
-        self._cursor_instance = Cursor(self, impl, timeout, self._echo)
+        self._cursor_instance = Cursor(self, impl, timeout, self._echo, isolation_level)
         return self._cursor_instance
 
     async def _cursor_impl(self, name=None, cursor_factory=None,

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -199,7 +199,8 @@ class Connection:
         return self._conn.isexecuting()
 
     def cursor(self, name=None, cursor_factory=None,
-               scrollable=None, withhold=False, timeout=None, isolation_level=None):
+               scrollable=None, withhold=False, timeout=None,
+               isolation_level=None):
         """A coroutine that returns a new cursor object using the connection.
 
         *cursor_factory* argument can be used to create non-standard
@@ -236,7 +237,9 @@ class Connection:
                                        cursor_factory=cursor_factory,
                                        scrollable=scrollable,
                                        withhold=withhold)
-        self._cursor_instance = Cursor(self, impl, timeout, self._echo, isolation_level)
+        self._cursor_instance = Cursor(
+            self, impl, timeout, self._echo, isolation_level
+        )
         return self._cursor_instance
 
     async def _cursor_impl(self, name=None, cursor_factory=None,

--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -13,7 +13,9 @@ class Cursor:
         self._impl = impl
         self._timeout = timeout
         self._echo = echo
-        self._transaction = Transaction(self, isolation_level or IsolationLevel.default)
+        self._transaction = Transaction(
+            self, isolation_level or IsolationLevel.default
+        )
 
     @property
     def echo(self):

--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -13,7 +13,7 @@ class Cursor:
         self._impl = impl
         self._timeout = timeout
         self._echo = echo
-        self._transaction = Transaction(self, IsolationLevel.repeatable_read)
+        self._transaction = Transaction(self, IsolationLevel.default)
 
     @property
     def echo(self):

--- a/aiopg/cursor.py
+++ b/aiopg/cursor.py
@@ -8,12 +8,12 @@ from .utils import _TransactionBeginContextManager
 
 
 class Cursor:
-    def __init__(self, conn, impl, timeout, echo):
+    def __init__(self, conn, impl, timeout, echo, isolation_level):
         self._conn = conn
         self._impl = impl
         self._timeout = timeout
         self._echo = echo
-        self._transaction = Transaction(self, IsolationLevel.default)
+        self._transaction = Transaction(self, isolation_level or IsolationLevel.default)
 
     @property
     def echo(self):

--- a/aiopg/transaction.py
+++ b/aiopg/transaction.py
@@ -1,7 +1,7 @@
 import enum
 import uuid
 import warnings
-from abc import ABC, abstractmethod
+from abc import ABC
 
 import psycopg2
 
@@ -11,12 +11,16 @@ __all__ = ('IsolationLevel', 'Transaction')
 
 
 class IsolationCompiler(ABC):
-    __slots__ = ()
+    __slots__ = ('_isolation_level', '_readonly', '_deferrable')
+
+    def __init__(self, isolation_level, readonly, deferrable):
+        self._isolation_level = isolation_level
+        self._readonly = readonly
+        self._deferrable = deferrable
 
     @property
-    @abstractmethod
     def name(self):
-        ...  # pragma: no cover
+        return self._isolation_level
 
     def savepoint(self, unique_id):
         return 'SAVEPOINT {}'.format(unique_id)
@@ -33,57 +37,12 @@ class IsolationCompiler(ABC):
     def rollback(self):
         return 'ROLLBACK'
 
-    @abstractmethod
     def begin(self):
-        ...  # pragma: no cover
-
-    def __repr__(self):
-        return self.name
-
-
-class ReadCommittedCompiler(IsolationCompiler):
-    __slots__ = ()
-
-    def __init__(self, readonly, deferrable):
-        if readonly or deferrable:
-            raise ValueError("Readonly or deferrable are not supported")
-
-    @property
-    def name(self):
-        return 'Read committed'
-
-    def begin(self):
-        return 'BEGIN ISOLATION LEVEL READ COMMITTED'
-
-
-class RepeatableReadCompiler(IsolationCompiler):
-    __slots__ = ()
-
-    def __init__(self, readonly, deferrable):
-        if readonly or deferrable:
-            raise ValueError("Readonly or deferrable are not supported")
-
-    @property
-    def name(self):
-        return 'Repeatable read'
-
-    def begin(self):
-        return 'BEGIN ISOLATION LEVEL REPEATABLE READ'
-
-
-class SerializableCompiler(IsolationCompiler):
-    __slots__ = ('_readonly', '_deferrable')
-
-    def __init__(self, readonly, deferrable):
-        self._readonly = readonly
-        self._deferrable = deferrable
-
-    @property
-    def name(self):
-        return 'Serializable'
-
-    def begin(self):
-        query = 'BEGIN ISOLATION LEVEL SERIALIZABLE'
+        query = 'BEGIN'
+        if self._isolation_level is not None:
+            query += (
+                ' ISOLATION LEVEL {}'.format(self._isolation_level.upper())
+            )
 
         if self._readonly:
             query += ' READ ONLY'
@@ -93,20 +52,40 @@ class SerializableCompiler(IsolationCompiler):
 
         return query
 
+    def __repr__(self):
+        return self.name
+
+
+class ReadCommittedCompiler(IsolationCompiler):
+    __slots__ = ()
+
+    def __init__(self, readonly, deferrable):
+        super().__init__('Read committed', readonly, deferrable)
+
+
+class RepeatableReadCompiler(IsolationCompiler):
+    __slots__ = ()
+
+    def __init__(self, readonly, deferrable):
+        super().__init__('Repeatable read', readonly, deferrable)
+
+
+class SerializableCompiler(IsolationCompiler):
+    __slots__ = ()
+
+    def __init__(self, readonly, deferrable):
+        super().__init__('Serializable', readonly, deferrable)
+
 
 class DefaultCompiler(IsolationCompiler):
     __slots__ = ()
 
     def __init__(self, readonly, deferrable):
-        if readonly or deferrable:
-            raise ValueError("Readonly or deferrable are not supported")
+        super().__init__(None, readonly, deferrable)
 
     @property
     def name(self):
         return 'Default'
-
-    def begin(self):
-        return 'BEGIN'
 
 
 class IsolationLevel(enum.Enum):

--- a/aiopg/transaction.py
+++ b/aiopg/transaction.py
@@ -16,7 +16,7 @@ class IsolationCompiler(ABC):
     @property
     @abstractmethod
     def name(self):
-        ...
+        ...  # pragma: no cover
 
     def savepoint(self, unique_id):
         return 'SAVEPOINT {}'.format(unique_id)
@@ -35,7 +35,7 @@ class IsolationCompiler(ABC):
 
     @abstractmethod
     def begin(self):
-        ...
+        ...  # pragma: no cover
 
     def __repr__(self):
         return self.name

--- a/aiopg/transaction.py
+++ b/aiopg/transaction.py
@@ -110,10 +110,10 @@ class DefaultCompiler(IsolationCompiler):
 
 
 class IsolationLevel(enum.Enum):
-    default = DefaultCompiler
     serializable = SerializableCompiler
     repeatable_read = RepeatableReadCompiler
     read_committed = ReadCommittedCompiler
+    default = DefaultCompiler
 
     def __call__(self, readonly, deferrable):
         return self.value(readonly, deferrable)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -463,6 +463,6 @@ class TcpProxy:
         self.connections.add(client_writer)
 
         await asyncio.wait([
-            self._pipe(server_reader, client_writer),
-            self._pipe(client_reader, server_writer),
+            asyncio.ensure_future(self._pipe(server_reader, client_writer)),
+            asyncio.ensure_future(self._pipe(client_reader, server_writer)),
         ])

--- a/tests/test_async_transaction.py
+++ b/tests/test_async_transaction.py
@@ -18,6 +18,7 @@ def engine(make_connection, loop):
 
 
 @pytest.mark.parametrize('isolation_level,readonly,deferrable', [
+    (IsolationLevel.default, False, False),
     (IsolationLevel.read_committed, False, False),
     (IsolationLevel.repeatable_read, False, False),
     (IsolationLevel.serializable, False, False),

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -5,7 +5,9 @@ import psycopg2
 import psycopg2.tz
 import pytest
 
+from aiopg import IsolationLevel
 from aiopg.connection import TIMEOUT
+from aiopg.transaction import ReadCommittedCompiler
 
 
 @pytest.fixture
@@ -302,6 +304,12 @@ async def test_echo_false(connect):
     conn = await connect()
     cur = await conn.cursor()
     assert not cur.echo
+
+
+async def test_isolation_level(connect):
+    conn = await connect()
+    cur = await conn.cursor(isolation_level=IsolationLevel.read_committed)
+    assert isinstance(cur._transaction._isolation, ReadCommittedCompiler)
 
 
 async def test_iter(connect):

--- a/tests/test_isolation_level.py
+++ b/tests/test_isolation_level.py
@@ -3,23 +3,6 @@ import pytest
 from aiopg import IsolationLevel
 
 
-@pytest.mark.parametrize('isolation_level', [
-    IsolationLevel.default,
-    IsolationLevel.read_committed,
-    IsolationLevel.repeatable_read,
-])
-@pytest.mark.parametrize('readonly, deferrable', [
-    (True, False),
-    (False, True),
-    (True, True),
-])
-def test_isolation_level_readonly_or_deferrable_not_supported(
-        isolation_level, readonly, deferrable
-):
-    with pytest.raises(ValueError):
-        isolation_level(readonly, deferrable)
-
-
 @pytest.mark.parametrize('isolation_level, name', [
     (IsolationLevel.default, 'Default'),
     (IsolationLevel.read_committed, 'Read committed'),

--- a/tests/test_isolation_level.py
+++ b/tests/test_isolation_level.py
@@ -1,0 +1,30 @@
+import pytest
+
+from aiopg import IsolationLevel
+
+
+@pytest.mark.parametrize('isolation_level', [
+    IsolationLevel.default,
+    IsolationLevel.read_committed,
+    IsolationLevel.repeatable_read,
+])
+@pytest.mark.parametrize('readonly, deferrable', [
+    (True, False),
+    (False, True),
+    (True, True),
+])
+def test_isolation_level_readonly_or_deferrable_not_supported(
+        isolation_level, readonly, deferrable
+):
+    with pytest.raises(ValueError):
+        isolation_level(readonly, deferrable)
+
+
+@pytest.mark.parametrize('isolation_level, name', [
+    (IsolationLevel.default, 'Default'),
+    (IsolationLevel.read_committed, 'Read committed'),
+    (IsolationLevel.repeatable_read, 'Repeatable read'),
+    (IsolationLevel.serializable, 'Serializable'),
+])
+def test_isolation_level_name(isolation_level, name):
+    assert isolation_level(False, False).name == name

--- a/tests/test_isolation_level.py
+++ b/tests/test_isolation_level.py
@@ -11,3 +11,58 @@ from aiopg import IsolationLevel
 ])
 def test_isolation_level_name(isolation_level, name):
     assert isolation_level(False, False).name == name
+
+
+@pytest.mark.parametrize(
+    'isolation_level, readonly, deferred, expected_begin',
+    [
+        (IsolationLevel.default, False, False, 'BEGIN'),
+        (IsolationLevel.default, True, False, 'BEGIN READ ONLY'),
+        (
+                IsolationLevel.read_committed,
+                False,
+                False,
+                'BEGIN ISOLATION LEVEL READ COMMITTED'
+        ),
+        (
+                IsolationLevel.read_committed,
+                True,
+                False,
+                'BEGIN ISOLATION LEVEL READ COMMITTED READ ONLY'
+        ),
+        (
+                IsolationLevel.repeatable_read,
+                False,
+                False,
+                'BEGIN ISOLATION LEVEL REPEATABLE READ'
+        ),
+        (
+                IsolationLevel.repeatable_read,
+                True,
+                False,
+                'BEGIN ISOLATION LEVEL REPEATABLE READ READ ONLY'
+        ),
+        (
+                IsolationLevel.serializable,
+                False,
+                False,
+                'BEGIN ISOLATION LEVEL SERIALIZABLE'
+        ),
+        (
+                IsolationLevel.serializable,
+                True,
+                False,
+                'BEGIN ISOLATION LEVEL SERIALIZABLE READ ONLY'
+        ),
+        (
+                IsolationLevel.serializable,
+                True,
+                True,
+                'BEGIN ISOLATION LEVEL SERIALIZABLE READ ONLY DEFERRABLE'
+        ),
+    ]
+)
+def test_isolation_level_begin(
+    isolation_level, readonly, deferred, expected_begin
+):
+    assert isolation_level(readonly, deferred).begin() == expected_begin

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -20,6 +20,7 @@ def engine(make_engine, loop):
 
 
 @pytest.mark.parametrize('isolation_level,readonly,deferrable', [
+    (IsolationLevel.default, False, False),
     (IsolationLevel.read_committed, False, False),
     (IsolationLevel.repeatable_read, False, False),
     (IsolationLevel.serializable, False, False),

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -2,7 +2,6 @@ import psycopg2
 import pytest
 
 from aiopg import IsolationLevel, Transaction
-from aiopg.transaction import IsolationCompiler
 
 
 @pytest.fixture
@@ -117,17 +116,6 @@ async def test_transaction_fail_oldstyle(engine, fn):
 def test_transaction_value_error():
     with pytest.raises(ValueError):
         Transaction(None, IsolationLevel.read_committed, readonly=True)
-
-
-def test_transaction_isolation_implemented():
-    class IsolationCompilerTest(IsolationCompiler):
-        def begin(self):
-            return super().begin()
-
-    tr = IsolationCompilerTest(False, False)
-
-    with pytest.raises(NotImplementedError):
-        tr.begin()
 
 
 async def test_transaction_finalization_warning(engine, monkeypatch):


### PR DESCRIPTION
PR introduces `IsolationLevel.default` and fixes `IsolationLevel.read_comitted` as it was mentioned by @dvarrazzo.

## Are there changes in behavior for the user?

Instead of hacking
```
        with (await pool.cursor()) as cur:
            # Set the connection in read committed isolation level
            # to avoid serialization failures on file lock
            # https://github.com/aio-libs/aiopg/issues/699
            # You can unlock the aiopg version from setup.py when this hack
            # is no more needed.
            cur._transaction = aiopg.Transaction(
                cur, aiopg.IsolationLevel.read_committed
            )
            yield cur
```
PR allows to pass `IsolationLevel`
```
        with (await pool.cursor(isolation_level=aiopg.IsolationLevel.read_committed)) as cur:
            yield cur
```

## Related issue number

Fixes #699

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
