### PR TITLE
Don't run ROLLBACK when the connection is closed.

### DIFF
--- a/aiopg/sa/connection.py
+++ b/aiopg/sa/connection.py
@@ -258,7 +258,7 @@ class SAConnection:
 
     async def _rollback_to_savepoint_impl(self, name, parent):
         if self._connection.closed:
-            self._transaction = None
+            self._transaction = parent
             return
 
         cur = await self._get_cursor()

--- a/aiopg/sa/connection.py
+++ b/aiopg/sa/connection.py
@@ -211,6 +211,10 @@ class SAConnection:
             self._transaction = None
 
     async def _rollback_impl(self):
+        if self._connection.closed:
+            self._transaction = None
+            return
+
         cur = await self._get_cursor()
         try:
             await cur.execute('ROLLBACK')
@@ -253,6 +257,10 @@ class SAConnection:
             cur.close()
 
     async def _rollback_to_savepoint_impl(self, name, parent):
+        if self._connection.closed:
+            self._transaction = None
+            return
+
         cur = await self._get_cursor()
         try:
             await cur.execute(f'ROLLBACK TO SAVEPOINT {name}')

--- a/aiopg/transaction.py
+++ b/aiopg/transaction.py
@@ -127,13 +127,15 @@ class Transaction:
 
     async def rollback(self):
         self._check_commit_rollback()
-        await self._cur.execute(self._isolation.rollback())
+        if not self._cur.closed:
+            await self._cur.execute(self._isolation.rollback())
         self._is_begin = False
 
     async def rollback_savepoint(self):
         self._check_release_rollback()
-        await self._cur.execute(
-            self._isolation.rollback_savepoint(self._unique_id))
+        if not self._cur.closed:
+            await self._cur.execute(
+                self._isolation.rollback_savepoint(self._unique_id))
         self._unique_id = None
 
     async def release_savepoint(self):

--- a/tests/test_sa_transaction.py
+++ b/tests/test_sa_transaction.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest import mock
 
 import pytest
@@ -411,3 +412,26 @@ async def test_transaction_mode(connect):
     res1 = await conn.scalar(select([func.count()]).select_from(tbl))
     assert 5 == res1
     await tr8.commit()
+
+
+async def test_timeout_in_transaction_context_manager(make_engine):
+    engine = await make_engine(timeout=1)
+    with pytest.raises(asyncio.TimeoutError):
+        async with engine.acquire() as connection:
+            async with connection.begin():
+                await connection.execute("SELECT pg_sleep(10)")
+
+    engine.terminate()
+    await engine.wait_closed()
+
+
+async def test_timeout_in_nested_transaction_context_manager(make_engine):
+    engine = await make_engine(timeout=1)
+    with pytest.raises(asyncio.TimeoutError):
+        async with engine.acquire() as connection:
+            async with connection.begin():
+                async with connection.begin_nested():
+                    await connection.execute("SELECT pg_sleep(10)")
+
+    engine.terminate()
+    await engine.wait_closed()

--- a/tests/test_sa_transaction.py
+++ b/tests/test_sa_transaction.py
@@ -447,7 +447,7 @@ async def test_cancel_in_transaction_context_manager(make_engine, loop):
                     connection.execute("SELECT pg_sleep(10)"))
 
                 async def cancel_soon():
-                    asyncio.sleep(1)
+                    await asyncio.sleep(1)
                     task.cancel()
 
                 loop.create_task(cancel_soon())
@@ -468,7 +468,7 @@ async def test_cancel_in_savepoint_context_manager(make_engine, loop):
                         connection.execute("SELECT pg_sleep(10)"))
 
                     async def cancel_soon():
-                        asyncio.sleep(1)
+                        await asyncio.sleep(1)
                         task.cancel()
 
                     loop.create_task(cancel_soon())

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -218,7 +218,7 @@ async def test_cancel_in_transaction_context_manager(engine, loop):
                     connection.execute("SELECT pg_sleep(10)"))
 
                 async def cancel_soon():
-                    asyncio.sleep(1)
+                    await asyncio.sleep(1)
                     task.cancel()
 
                 loop.create_task(cancel_soon())
@@ -236,7 +236,7 @@ async def test_cancel_in_savepoint_context_manager(engine, loop):
                         connection.execute("SELECT pg_sleep(10)"))
 
                     async def cancel_soon():
-                        asyncio.sleep(1)
+                        await asyncio.sleep(1)
                         task.cancel()
 
                     loop.create_task(cancel_soon())


### PR DESCRIPTION
Fixes #777.

This can be caused when a query times out while running, for example, and the connection is closed as a result (as opposed to cancelling the query, since PR #570). In this case, we would rather not emit the ROLLBACK (the connection is already closed, so the transaction is over anyway), rather than raising an exception when trying to use a connection which is already closed.

I wasn't sure if it was cleaner to do this here (inside the implementation of rollback) or in the context manager of the transaction. The disadvantage of this implementation is that here we are also affecting any rollback that someone does manually, but implementing it in the context manager is awkward since it doesn't have access to the connection object, and we wouldn't have a way to set `self._transaction = None` and `self._is_begin = False`.

If you think the side effect of making all ROLLBACKs on a closed connection silently do nothing is fine, we can leave it like this. Otherwise maybe we can add another intermediate method `rollback_unless_closed` or something like that which the context manager calls, which does the check and calls rollback if necessary.