### PR TITLE
Fix compatibility with SA 1.4 for IN statement

### DIFF
--- a/aiopg/sa/connection.py
+++ b/aiopg/sa/connection.py
@@ -103,7 +103,8 @@ class SAConnection:
         if isinstance(query, str):
             await cursor.execute(query, dp)
         elif isinstance(query, ClauseElement):
-            compiled = query.compile(dialect=self._dialect, compile_kwargs=self._query_compile_kwargs)
+            compiled = query.compile(dialect=self._dialect,
+                                     compile_kwargs=self._query_compile_kwargs)
             # parameters = compiled.params
             if not isinstance(query, DDLElement):
                 if dp and isinstance(dp, (list, tuple)):
@@ -403,8 +404,11 @@ def _distill_params(multiparams, params):
     elif len(multiparams) == 1:
         zero = multiparams[0]
         if isinstance(zero, (list, tuple)):
-            if not zero or hasattr(zero[0], '__iter__') and \
-                not hasattr(zero[0], 'strip'):
+            if (
+                not zero
+                or hasattr(zero[0], '__iter__')
+                and not hasattr(zero[0], 'strip')
+            ):
                 # execute(stmt, [{}, {}, {}, ...])
                 # execute(stmt, [(), (), (), ...])
                 return zero
@@ -418,8 +422,10 @@ def _distill_params(multiparams, params):
             # execute(stmt, "value")
             return [[zero]]
     else:
-        if (hasattr(multiparams[0], '__iter__') and
-            not hasattr(multiparams[0], 'strip')):
+        if (
+            hasattr(multiparams[0], '__iter__') and
+            not hasattr(multiparams[0], 'strip')
+        ):
             return multiparams
         else:
             return [multiparams]

--- a/aiopg/sa/connection.py
+++ b/aiopg/sa/connection.py
@@ -103,10 +103,12 @@ class SAConnection:
         if isinstance(query, str):
             await cursor.execute(query, dp)
         elif isinstance(query, ClauseElement):
-            compiled = query.compile(dialect=self._dialect,
-                                     compile_kwargs=self._query_compile_kwargs)
             # parameters = compiled.params
             if not isinstance(query, DDLElement):
+                compiled = query.compile(
+                    dialect=self._dialect,
+                    compile_kwargs=self._query_compile_kwargs,
+                )
                 if dp and isinstance(dp, (list, tuple)):
                     if isinstance(query, UpdateBase):
                         dp = {c.key: pval
@@ -133,6 +135,7 @@ class SAConnection:
                 result_map = compiled._result_columns
 
             else:
+                compiled = query.compile(dialect=self._dialect)
                 if dp:
                     raise exc.ArgumentError("Don't mix sqlalchemy DDL clause "
                                             "and execution with parameters")

--- a/aiopg/sa/engine.py
+++ b/aiopg/sa/engine.py
@@ -89,6 +89,8 @@ class Engine:
     create_engine coroutine.
     """
 
+    CONNECTION_CLASS = SAConnection
+
     __slots__ = ("_dialect", "_pool", "_dsn", "_loop")
 
     def __init__(self, dialect, pool, dsn):
@@ -168,7 +170,7 @@ class Engine:
 
     async def _acquire(self):
         raw = await self._pool.acquire()
-        conn = SAConnection(raw, self)
+        conn = self.CONNECTION_CLASS(raw, self)
         return conn
 
     def release(self, conn):

--- a/aiopg/sa/engine.py
+++ b/aiopg/sa/engine.py
@@ -89,8 +89,6 @@ class Engine:
     create_engine coroutine.
     """
 
-    CONNECTION_CLASS = SAConnection
-
     __slots__ = ("_dialect", "_pool", "_dsn", "_loop")
 
     def __init__(self, dialect, pool, dsn):
@@ -170,7 +168,7 @@ class Engine:
 
     async def _acquire(self):
         raw = await self._pool.acquire()
-        conn = self.CONNECTION_CLASS(raw, self)
+        conn = SAConnection(raw, self)
         return conn
 
     def release(self, conn):

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,5 +10,5 @@ pytest-sugar==0.9.4
 pytest-timeout==1.4.2
 sphinxcontrib-asyncio==0.3.0
 psycopg2-binary==2.8.6
-sqlalchemy[postgresql_psycopg2binary]==1.3.23
+sqlalchemy[postgresql_psycopg2binary]==1.4.2
 async-timeout==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from setuptools import setup, find_packages
 
 install_requires = ['psycopg2-binary>=2.8.4', 'async_timeout>=3.0,<4.0']
-extras_require = {'sa': ['sqlalchemy[postgresql_psycopg2binary]>=1.1,<1.4']}
+extras_require = {'sa': ['sqlalchemy[postgresql_psycopg2binary]>=1.3']}
 
 
 def read(*parts):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from setuptools import setup, find_packages
 
 install_requires = ['psycopg2-binary>=2.8.4', 'async_timeout>=3.0,<4.0']
-extras_require = {'sa': ['sqlalchemy[postgresql_psycopg2binary]>=1.3']}
+extras_require = {'sa': ['sqlalchemy[postgresql_psycopg2binary]>=1.3,<1.5']}
 
 
 def read(*parts):

--- a/tests/test_sa_connection.py
+++ b/tests/test_sa_connection.py
@@ -71,6 +71,18 @@ async def test_execute_sa_select(connect):
     assert 'first' == row.name
 
 
+async def test_execute_sa_select_with_in(connect):
+    conn = await connect()
+    await conn.execute(tbl.insert(), 2, 'second')
+    await conn.execute(tbl.insert(), 3, 'third')
+
+    res = await conn.execute(tbl.select().where(tbl.c.name.in_(['first', 'second'])))
+    rows = await res.fetchall()
+    assert 2 == len(rows)
+    assert (1, 'first') == rows[0]
+    assert (2, 'second') == rows[1]
+
+
 async def test_execute_sa_insert_with_dict(connect):
     conn = await connect()
     await conn.execute(tbl.insert(), {"id": 2, "name": "second"})

--- a/tests/test_sa_connection.py
+++ b/tests/test_sa_connection.py
@@ -76,7 +76,8 @@ async def test_execute_sa_select_with_in(connect):
     await conn.execute(tbl.insert(), 2, 'second')
     await conn.execute(tbl.insert(), 3, 'third')
 
-    res = await conn.execute(tbl.select().where(tbl.c.name.in_(['first', 'second'])))
+    res = await conn.execute(tbl.select().where(
+        tbl.c.name.in_(['first', 'second'])))
     rows = await res.fetchall()
     assert 2 == len(rows)
     assert (1, 'first') == rows[0]


### PR DESCRIPTION
Fixes #798

Now in SA, there are two options for how to compile the query.
`literal_binds` and `render_postcompile`
Both options work correctly with the current code base since `aiopg` does not support executemany
https://docs.sqlalchemy.org/en/14/changelog/migration_14.html#all-in-expressions-render-parameters-for-each-value-in-the-list-on-the-fly-e-g-expanding-parameters

Unfortunately, this solution does not support late-expanded
https://docs.sqlalchemy.org/en/14/changelog/migration_12.html#late-expanded-in-parameter-sets-allow-in-expressions-with-cached-statements
to support this feature need to rework the `_execute` method of the `SAConnection` class