### PR TITLE
raise ResourceClosedError if we try to open a cursor on a closed SAConnection

### DIFF
--- a/aiopg/sa/connection.py
+++ b/aiopg/sa/connection.py
@@ -82,6 +82,8 @@ class SAConnection:
         return _SAConnectionContextManager(coro)
 
     async def _open_cursor(self):
+        if self._connection is None:
+            raise exc.ResourceClosedError("This connection is closed.")
         cursor = await self._connection.cursor()
         self._cursors.add(cursor)
         return cursor

--- a/tests/test_sa_connection.py
+++ b/tests/test_sa_connection.py
@@ -389,3 +389,11 @@ async def test_create_table(connect):
 
     res = await conn.execute("SELECT * FROM sa_tbl")
     assert 0 == len(await res.fetchall())
+
+
+async def test_execute_when_closed(connect):
+    conn = await connect()
+    await conn.close()
+
+    with pytest.raises(sa.ResourceClosedError):
+        await conn.execute(tbl.select())


### PR DESCRIPTION
solves #809 