### PR TITLE
Fix ClosableQueue.get on cancellation, close it on Connection.close

### DIFF
--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -812,7 +812,7 @@ class Connection:
                     # chain exception otherwise
                     exc2.__cause__ = exc
                     exc = exc2
-            self.notifies.close(exc)
+            self._notifies_proxy.close(exc)
             if waiter is not None and not waiter.done():
                 waiter.set_exception(exc)
         else:

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -767,7 +767,7 @@ class Connection:
         self._writing = False
         self._echo = echo
         self._notifies = asyncio.Queue()  # type: ignore
-        self._notifies_proxy = ClosableQueue(self._notifies)
+        self._notifies_proxy = ClosableQueue(self._notifies, self._loop)
         self._weakref = weakref.ref(self)
         self._loop.add_reader(
             self._fileno, self._ready, self._weakref  # type: ignore
@@ -985,6 +985,10 @@ class Connection:
             self._waiter.set_exception(
                 psycopg2.OperationalError("Connection closed")
             )
+
+        self._notifies_proxy.close(
+            psycopg2.OperationalError("Connection closed")
+        )
 
     def close(self) -> "asyncio.Future[None]":
         self._close()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,3 +68,12 @@ async def test_closable_queue_get_nowait_noclose(loop):
     assert queue.get_nowait() == 1
     with pytest.raises(asyncio.QueueEmpty):
         queue.get_nowait()
+
+
+async def test_closable_queue_get_cancellation(loop):
+    queue = ClosableQueue(asyncio.Queue(), loop)
+    get_task = loop.create_task(queue.get())
+    await asyncio.sleep(0.1)
+    get_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await get_task

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,9 +5,9 @@ import pytest
 from aiopg.utils import ClosableQueue
 
 
-async def test_closable_queue_noclose():
+async def test_closable_queue_noclose(loop):
     the_queue = asyncio.Queue()
-    queue = ClosableQueue(the_queue)
+    queue = ClosableQueue(the_queue, loop)
     assert queue.empty()
     assert queue.qsize() == 0
 
@@ -24,7 +24,7 @@ async def test_closable_queue_noclose():
 
 async def test_closable_queue_close(loop):
     the_queue = asyncio.Queue()
-    queue = ClosableQueue(the_queue)
+    queue = ClosableQueue(the_queue, loop)
     v1 = None
 
     async def read():
@@ -45,7 +45,7 @@ async def test_closable_queue_close(loop):
 
 async def test_closable_queue_close_get_nowait(loop):
     the_queue = asyncio.Queue()
-    queue = ClosableQueue(the_queue)
+    queue = ClosableQueue(the_queue, loop)
 
     await the_queue.put(1)
     queue.close(RuntimeError("connection closed"))
@@ -63,7 +63,7 @@ async def test_closable_queue_close_get_nowait(loop):
 
 async def test_closable_queue_get_nowait_noclose(loop):
     the_queue = asyncio.Queue()
-    queue = ClosableQueue(the_queue)
+    queue = ClosableQueue(the_queue, loop)
     await the_queue.put(1)
     assert queue.get_nowait() == 1
     with pytest.raises(asyncio.QueueEmpty):


### PR DESCRIPTION
We had the following crutch to force reconnection, it was necessary before the fix #559.

```
async with connection.cursor() as cursor:
    await cursor.execute(f"LISTEN {self._channel}")
    while True:
        try:
            async with async_timeout.timeout(self._reconnect_timeout):
                message = await connection.notifies.get()
                yield message.payload
        except asyncio.TimeoutError:
            logger.info("Too long delay between notifications. We have to reconnect")
            break
```

It helped to find the issue in `ClosableQueue` implementation: `ClosableQueue.get` doesn't handle cancellation well, `get loop.create_task(self._queue.get())` is not cancelled if a cancellation happens in `await asyncio.wait([get, self._close_exception], return_when=asyncio.FIRST_COMPLETED)`.

```
Task was destroyed but it is pending!
task: <Task pending name='Task-891205' coro=<Queue.get() running at /usr/local/lib/python3.9/asyncio/queues.py:166> wait_for=<Future pending cb=[<TaskWakeupMethWrapper object at 0x7f3a938c2310>()]>>
```
