### PR TITLE
Suppress "Future exception was never retrieved"

### DIFF
--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -981,14 +981,15 @@ class Connection:
 
         self._conn.close()
 
-        if self._waiter is not None and not self._waiter.done():
-            self._waiter.set_exception(
+        if not self._loop.is_closed():
+            if self._waiter is not None and not self._waiter.done():
+                self._waiter.set_exception(
+                    psycopg2.OperationalError("Connection closed")
+                )
+
+            self._notifies_proxy.close(
                 psycopg2.OperationalError("Connection closed")
             )
-
-        self._notifies_proxy.close(
-            psycopg2.OperationalError("Connection closed")
-        )
 
     def close(self) -> "asyncio.Future[None]":
         self._close()

--- a/aiopg/utils.py
+++ b/aiopg/utils.py
@@ -143,6 +143,8 @@ class ClosableQueue:
         self._loop = loop
         self._queue = queue
         self._close_event = loop.create_future()
+        # suppress Future exception was never retrieved
+        self._close_event.add_done_callback(lambda f: f.exception())
 
     def close(self, exception: Exception) -> None:
         if self._close_event.done():


### PR DESCRIPTION
The fix suppresses the following error via ugly hack using `.add_done_callback(lambda f: f.exception())`:

```
Future exception was never retrieved
future: <Future finished exception=OperationalError('Connection closed')>
```

Also I had to add `loop.is_closed()` to suppress this error in tests:

```
Traceback (most recent call last):
  File "/Users/yurypliner/Sources/aiopg/aiopg/pool.py", line 476, in __del__
    conn.close()
  File "/Users/yurypliner/Sources/aiopg/aiopg/connection.py", line 995, in close
    self._close()
  File "/Users/yurypliner/Sources/aiopg/aiopg/connection.py", line 990, in _close
    self._notifies_proxy.close(
  File "/Users/yurypliner/Sources/aiopg/aiopg/utils.py", line 152, in close
    self._close_event.set_exception(exception)
  File "/Users/yurypliner/.pyenv/versions/3.9.2/lib/python3.9/asyncio/base_events.py", line 746, in call_soon
    self._check_closed()
  File "/Users/yurypliner/.pyenv/versions/3.9.2/lib/python3.9/asyncio/base_events.py", line 510, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```