### PR TITLE
Update PostgreSQL versions used in tests

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+1.3.2 (2021-07-XX)
+^^^^^^^^^^^^^^^^^^
+
+* Use newer PostgreSQL versions in tests `#865 <https://github.com/aio-libs/aiopg/pull/865>`_
+
+
 1.3.1 (2021-07-08)
 ^^^^^^^^^^^^^^^^^^
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,9 +1,3 @@
-1.3.2 (2021-07-XX)
-^^^^^^^^^^^^^^^^^^
-
-* Use newer PostgreSQL versions in tests `#865 <https://github.com/aio-libs/aiopg/pull/865>`_
-
-
 1.3.1 (2021-07-08)
 ^^^^^^^^^^^^^^^^^^
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,7 @@ def pytest_addoption(parser):
         help=(
             "Postgres server versions. "
             "May be used several times. "
-            "Available values: 9.3, 9.4, 9.5, all"
+            "Available values: 9.6, 10, 11, 12, 13, all"
         ),
     )
     parser.addoption(
@@ -130,9 +130,9 @@ def pytest_generate_tests(metafunc):
     if "pg_tag" in metafunc.fixturenames:
         tags = set(metafunc.config.option.pg_tag)
         if not tags:
-            tags = ["9.5"]
+            tags = ["13"]
         elif "all" in tags:
-            tags = ["9.3", "9.4", "9.5"]
+            tags = ["9.6", "10", "11", "12", "13"]
         else:
             tags = list(tags)
         metafunc.parametrize("pg_tag", tags, scope="session")

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -22,8 +22,7 @@ def connect(make_connection):
             await cur.execute("DROP TABLE IF EXISTS tbl2")
             await cur.execute(
                 """CREATE TABLE tbl2
-                                      (id int, name varchar(255))
-                                      WITH OIDS"""
+                                      (id int, name varchar(255))"""
             )
             await cur.execute("DROP FUNCTION IF EXISTS inc(val integer)")
             await cur.execute(
@@ -184,10 +183,6 @@ async def test_rows(cursor):
     assert 0 == cursor.rownumber
     await cursor.fetchone()
     assert 1 == cursor.rownumber
-
-    assert 0 == cursor.lastrowid
-    await cursor.execute("INSERT INTO tbl2 VALUES (%s, %s)", (4, "d"))
-    assert 0 != cursor.lastrowid
 
 
 async def test_query(cursor):


### PR DESCRIPTION
## What do these changes do?

Tests were using outdated/deprecated PostgreSQL versions. For better results tests should run over an actual PostgreSQL version.

I also had to remove some assertions in tests since they decided to phase out `oids` feature since PostgreSQL 12. See: https://stackoverflow.com/a/57022291/10650942

## Are there changes in behavior for the user?

No. Only in tests.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
