### PR TITLE
Update version regex after blackifying code

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 
 def get_release():
-    regexp = re.compile(r"^__version__\W*=\W*'([\d.abrc]+)'")
+    regexp = re.compile(r"^__version__\W*=\W*\"([\d.abrc]+)\"")
     init_py = Path(__file__).resolve().parent.parent / 'aiopg' / '__init__.py'
     with init_py.open() as f:
         for line in f:


### PR DESCRIPTION
## What do these changes do?

Fix `make docs` command to build documentation site locally. It used to fail like this:

```
$ make doc
cd docs && rm -rf _build/html
cd docs && make html
make[1]: Entering directory '/home/br0ke/git/aiopg/docs'
sphinx-build -b html -d _build/doctrees   . _build/html
Running Sphinx v4.0.3

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/br0ke/git/aiopg/.env/lib64/python3.8/site-packages/sphinx/config.py", line 323, in eval_config_file
    exec(code, namespace)
  File "/home/br0ke/git/aiopg/docs/conf.py", line 85, in <module>
    release = get_release()
  File "/home/br0ke/git/aiopg/docs/conf.py", line 29, in get_release
    raise RuntimeError('Cannot find version in aiopg/__init__.py')
RuntimeError: Cannot find version in aiopg/__init__.py

make[1]: *** [Makefile:53: html] Error 2
make[1]: Leaving directory '/home/br0ke/git/aiopg/docs'
make: *** [Makefile:7: doc] Error 2
```

## Are there changes in behavior for the user?

No. This fix is only for maintainers.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
