### PR TITLE
Run linters in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,19 +42,39 @@ jobs:
         python setup.py check -rms
         codecov
 
+  lint:
+    name: Run linters
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          pip install -e .
+          pip install -r requirements.txt
+      - name: Run linters
+        run: |
+          make lint
+
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: test
+    needs:
+      - test
+      - lint
     # Run only on pushing a tag
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Setup Python 3.8
+    - name: Setup Python 3.9
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.9
     - name: Install dependencies
       run:
         python -m pip install -U pip wheel twine

--- a/aiopg/utils.py
+++ b/aiopg/utils.py
@@ -139,7 +139,11 @@ class ClosableQueue:
 
     __slots__ = ("_loop", "_queue", "_close_event")
 
-    def __init__(self, queue: asyncio.Queue, loop: asyncio.AbstractEventLoop):
+    def __init__(
+        self,
+        queue: asyncio.Queue,  # type: ignore
+        loop: asyncio.AbstractEventLoop,
+    ):
         self._loop = loop
         self._queue = queue
         self._close_event = loop.create_future()

--- a/examples/transaction.py
+++ b/examples/transaction.py
@@ -1,6 +1,6 @@
 import asyncio
 
-from aiopg import IsolationLevel, create_pool, Transaction
+from aiopg import IsolationLevel, Transaction, create_pool
 
 dsn = "dbname=aiopg user=aiopg password=passwd host=127.0.0.1"
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 import gc
 import socket
 import sys

--- a/tests/test_cursor.py
+++ b/tests/test_cursor.py
@@ -1,6 +1,6 @@
 import asyncio
-import time
 import datetime
+import time
 
 import psycopg2
 import psycopg2.tz


### PR DESCRIPTION
## What do these changes do?

The project seems to use `flake8`, `mypy`, `black` & `isort` but doesn't enforce it in the CI. This PR makes it necessary for these tools to pass successfully.

I had to `# type: ignore` one type errors. At the moment I don't have a clear understanding of how to fix this issue better. The PR still adds some value because all other parts of the project will be type-checked, and no new type violations will be allowed.

## Are there changes in behavior for the user?

No. This PR affects only maintainers and future contributors.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
