### PR TITLE
fix Cursor.mogrify type hint: it returns bytes, not str

### DIFF
--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -481,10 +481,10 @@ class Cursor:
             _rollback_transaction,
         )
 
-    def mogrify(self, operation: str, parameters: Any = None) -> str:
+    def mogrify(self, operation: str, parameters: Any = None) -> bytes:
         """Return a query string after arguments binding.
 
-        The string returned is exactly the one that would be sent to
+        The byte string returned is exactly the one that would be sent to
         the database running the .execute() method or similar.
 
         """


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

the type hint for Cusor.mogrify is wrong.  It returns bytes, not str (for proof, look for the unit test test_mogrify).  This fixes the type hint, and inline doc.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
