### PR TITLE
repeir error NotImplemented for Windows OS

### DIFF
--- a/aiopg/utils.py
+++ b/aiopg/utils.py
@@ -14,7 +14,10 @@ from typing import (
     Union,
 )
 
-if sys.version_info >= (3, 7, 0):
+if sys.version_info >= (3, 8, 0) and sys.platform == 'win32':
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    __get_running_loop = asyncio.get_running_loop
+elif sys.version_info >= (3, 7, 0):
     __get_running_loop = asyncio.get_running_loop
 else:
 


### PR DESCRIPTION
## What do these changes do?

Repair error NotImplemented for Windows OS and Python 3.8

## Are there changes in behavior for the user?

No

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (I don't know how check Windows OS in CI)
- [ ] Documentation reflects the changes (don't need)
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * ensure type is one of the following:
    * `.bugfix`: Signifying a bug fix.
