### PR TITLE
Bump async_timeout to ~4.0a2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ pytest-timeout==1.4.2
 sphinxcontrib-asyncio==0.3.0
 psycopg2-binary==2.9.1
 sqlalchemy[postgresql_psycopg2binary]==1.4.22
-async-timeout==3.0.1
+async-timeout==4.0.0a3
 mypy==0.910
 black==21.7b0
 six==1.16.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 
-install_requires = ["psycopg2-binary>=2.8.4", "async_timeout>=3.0,<4.0"]
+install_requires = ["psycopg2-binary>=2.8.4", "async_timeout>=4.0a2,<5.0"]
 extras_require = {"sa": ["sqlalchemy[postgresql_psycopg2binary]>=1.3,<1.5"]}
 
 


### PR DESCRIPTION
## What do these changes do?

Bump async_timeout

## Are there changes in behavior for the user?

aiopg version 1.3.2 conflicts with aiohttp 3.8.0

```
The conflict is caused by:
    aiohttp 3.8.0 depends on async-timeout<5.0 and >=4.0.0a3
    aiopg 1.3.2 depends on async-timeout<4.0 and >=3.0
```