### PR TITLE
Make sure connection._ready() does not stall on bad file descriptor

### DIFF
--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -834,10 +834,13 @@ class Connection:
                     self._writing = False
             elif state == psycopg2.extensions.POLL_WRITE:
                 if not self._writing:
-                    self._loop.add_writer(
-                        self._fileno, self._ready, weak_self  # type: ignore
-                    )
-                    self._writing = True
+                    try:
+                        self._loop.add_writer(
+                            self._fileno, self._ready, weak_self  # type: ignore
+                        )
+                        self._writing = True
+                    except Exception as e:
+                        waiter.set_exception(e)
             elif state == psycopg2.extensions.POLL_ERROR:
                 self._fatal_error(
                     "Fatal error on aiopg connection: "

--- a/aiopg/connection.py
+++ b/aiopg/connection.py
@@ -839,7 +839,7 @@ class Connection:
                             self._fileno, self._ready, weak_self  # type: ignore
                         )
                         self._writing = True
-                    except Exception as e:
+                    except OSError as e:
                         waiter.set_exception(e)
             elif state == psycopg2.extensions.POLL_ERROR:
                 self._fatal_error(

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 
-install_requires = ["psycopg2-binary>=2.8.4", "async_timeout>=3.0,<4.0"]
+install_requires = ["psycopg2-binary>=2.8.4", "async_timeout>=3.0,<5.0"]
 extras_require = {"sa": ["sqlalchemy[postgresql_psycopg2binary]>=1.3,<1.5"]}
 
 


### PR DESCRIPTION
With @emk

We've observed "[Errno 2] No such file or directory" coming from add_writer(). When this happens, nobody notifies _waiter that there has been an exception and this hangs the program.

We haven't managed to create a local repo - whenever we (for example) kill -9 a postgres process while an aiopg client is writing to it, we get the intended psycopg2.OperationalError("Connection closed").

Here's the backtrace of the error seen in the wild:

Exception in callback Connection._ready(<weakref at 0...x7efddf120890>) at /root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.7/site-packages/aiopg/connection.py:779
handle: <Handle Connection._ready(<weakref at 0...x7efddf120890>) at /root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.7/site-packages/aiopg/connection.py:779>
Traceback (most recent call last):
  [... app code ...]
  File "/usr/lib/python3.7/asyncio/base_events.py", line 566, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.7/asyncio/base_events.py", line 534, in run_forever
    self._run_once()
  File "/usr/lib/python3.7/asyncio/base_events.py", line 1771, in _run_once
    handle._run()
  File "/usr/lib/python3.7/asyncio/events.py", line 88, in _run
    self._context.run(self._callback, *self._args)
  File "/root/.local/share/virtualenvs/app-4PlAip0Q/lib/python3.7/site-packages/aiopg/connection.py", line 838, in _ready
    self._fileno, self._ready, weak_self  # type: ignore
  File "/usr/lib/python3.7/asyncio/selector_events.py", line 334, in add_writer
    return self._add_writer(fd, callback, *args)
  File "/usr/lib/python3.7/asyncio/selector_events.py", line 294, in _add_writer
    (reader, handle))
  File "/usr/lib/python3.7/selectors.py", line 389, in modify
    self._selector.modify(key.fd, selector_events)
FileNotFoundError: [Errno 2] No such file or directory

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
