### PR TITLE
Fix pool size limit check for unlimited pools

### DIFF
--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -352,7 +352,7 @@ class Pool:
         if self._free:
             return
 
-        if override_min and self.size < (self.maxsize or 0):
+        if override_min and (not self.maxsize or self.size < self.maxsize):
             self._acquiring += 1
             try:
                 conn = await connect(

--- a/tests/test_pool.py
+++ b/tests/test_pool.py
@@ -441,6 +441,13 @@ async def test_unlimited_size(create_pool):
     assert pool._free.maxlen is None
 
 
+async def test_unlimited_size_minsize_0_acquire(create_pool):
+    pool = await create_pool(minsize=0, maxsize=0)
+    async with pool.acquire() as conn:
+        cur = await conn.cursor()
+        await cur.execute("SELECT 1")
+
+
 async def test_connection_closed_after_timeout(create_pool):
     async def sleep(conn):
         cur = await conn.cursor()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix pool size limit check for unlimited connection pools.
AS IS: acquiring a connection on a pool with `minsize=0, maxsize=0` blocks forever.
AS EXPECTED: acquiring a connection on a pool with `minsize=0, maxsize=0` returns a created connection.

## Are there changes in behavior for the user?

These changes will allow to create a pool with settings `minsize=0, maxsize=0`.

## Related issue number
https://github.com/aio-libs/aiopg/issues/311 - even though the `TypeError` has been fixed, it is still impossible to use a pool with `minsize=0, maxsize=0`.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
