### PR TITLE
Fix compatibility with SA 1.4.38. Pass escape_names.

### DIFF
--- a/aiopg/sa/engine.py
+++ b/aiopg/sa/engine.py
@@ -17,8 +17,8 @@ except ImportError:  # pragma: no cover
 
 
 class APGCompiler_psycopg2(PGCompiler_psycopg2):
-    def construct_params(self, params=None, _group_number=None, _check=True):
-        pd = super().construct_params(params, _group_number, _check)
+    def construct_params(self, *args, **kwargs):
+        pd = super().construct_params(*args, **kwargs)
 
         for column in self.prefetch:
             pd[column.key] = self._exec_default(column.default)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pytest-sugar==0.9.4
 pytest-timeout==1.4.2
 sphinxcontrib-asyncio==0.3.0
 psycopg2-binary==2.9.1
-sqlalchemy[postgresql_psycopg2binary]==1.4.22
+sqlalchemy[postgresql_psycopg2binary]==1.4.38
 async-timeout==4.0.0
 mypy==0.910
 black==21.7b0

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ psycopg2-binary==2.9.1
 sqlalchemy[postgresql_psycopg2binary]==1.4.38
 async-timeout==4.0.0
 mypy==0.910
-black==21.7b0
+black==22.3.0
 six==1.16.0


### PR DESCRIPTION
## What do these changes do?

In version SA 1.4.38, a new argument was added to the signature of the `construct_params` method.
To avoid such a problem in the future, parameters are passed through args, kwargs.
This change is backward compatible

## Are there changes in behavior for the user?

No

## Related issue number

#890 Incampatible with SQLAlchemy 1.4.38 and higher 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
