### PR TITLE
Close connection when _fill_free_pool is cancelled.

### DIFF
--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -332,6 +332,7 @@ class Pool:
 
         while self.size < self.minsize:
             self._acquiring += 1
+            conn = None
             try:
                 conn = await connect(
                     self._dsn,
@@ -348,7 +349,8 @@ class Pool:
                 self._free.append(conn)
                 self._cond.notify()
             except asyncio.CancelledError:
-                conn.close()
+                if conn is not None:
+                    conn.close()
                 raise
             finally:
                 self._acquiring -= 1
@@ -357,6 +359,7 @@ class Pool:
 
         if override_min and (not self.maxsize or self.size < self.maxsize):
             self._acquiring += 1
+            conn = None
             try:
                 conn = await connect(
                     self._dsn,
@@ -373,7 +376,8 @@ class Pool:
                 self._free.append(conn)
                 self._cond.notify()
             except asyncio.CancelledError:
-                conn.close()
+                if conn is not None:
+                    conn.close()
                 raise
             finally:
                 self._acquiring -= 1

--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -347,6 +347,9 @@ class Pool:
                 # raise exception if pool is closing
                 self._free.append(conn)
                 self._cond.notify()
+            except asyncio.CancelledError:
+                conn.close()
+                raise
             finally:
                 self._acquiring -= 1
         if self._free:
@@ -369,6 +372,9 @@ class Pool:
                 # raise exception if pool is closing
                 self._free.append(conn)
                 self._cond.notify()
+            except asyncio.CancelledError:
+                conn.close()
+                raise
             finally:
                 self._acquiring -= 1
 


### PR DESCRIPTION
Cancelling _fill_free_pool before a new connection is added to self._free prevents it from being cleaned up which causes a lingering connection and eventually the postgresql server running out of sockets.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` (e.g. `588.bugfix`)
  * if you don't have an `issue_id` change it to the pr id after creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: `Fix issue with non-ascii contents in doctest text files.`
