### PR TITLE
Don't depend on async-timeout for Python 3.11+

### DIFF
--- a/aiopg/pool.py
+++ b/aiopg/pool.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+import sys
 import warnings
 from types import TracebackType
 from typing import (
@@ -13,7 +14,10 @@ from typing import (
     Type,
 )
 
-import async_timeout
+if sys.version_info >= (3, 11):
+    import asyncio as async_timeout
+else:
+    import async_timeout
 import psycopg2.extensions
 
 from .connection import TIMEOUT, Connection, Cursor, connect

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 
-install_requires = ["psycopg2-binary>=2.9.5", "async_timeout>=3.0,<5.0"]
+install_requires = ["psycopg2-binary>=2.9.5", "async_timeout>=3.0,<5.0; python_version < \"3.11\""]
 extras_require = {"sa": ["sqlalchemy[postgresql_psycopg2binary]>=1.4,<2.1"]}
 
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 
-install_requires = ["psycopg2-binary>=2.9.5", "async_timeout>=3.0,<5.0; python_version < \"3.11\""]
+install_requires = ["psycopg2-binary>=2.9.5", "async_timeout>=3.0,<5.0; python_version < '3.11'"]
 extras_require = {"sa": ["sqlalchemy[postgresql_psycopg2binary]>=1.4,<2.1"]}
 
 


### PR DESCRIPTION
This library has effectively been upstreamed into Python 3.11+ and is no longer actively supported.

See: https://archlinux.org/todo/deprecate-python-async-timeout/